### PR TITLE
Remove RPCs from generated services

### DIFF
--- a/awsiot/__init__.py
+++ b/awsiot/__init__.py
@@ -19,9 +19,12 @@ __all__ = [
 from aws_crt import mqtt
 from concurrent.futures import Future
 import json
-from threading import RLock
-from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union
-from uuid import uuid4
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+T = TypeVar('T')
+
+PayloadObj = Dict[str, Any]
+PayloadToClassFn = Callable[[PayloadObj], T]
 
 class MqttServiceClient(object):
     """
@@ -31,316 +34,83 @@ class MqttServiceClient(object):
     def __init__(self, mqtt_connection):
         # type: (mqtt.Connection) -> None
         self._mqtt_connection = mqtt_connection # type: mqtt.Connection
-        self._nonce_rpc_topics = {} # type: Dict[str, _NonceRpcTopicEntry]
-        self._nonce_rpc_lock = RLock() # type: RLock
-        self._fifo_rpc_topics = {} # type: Dict[str, _FifoRpcTopicEntry]
-        self._fifo_rpc_lock = RLock() # type: RLock
 
     @property
     def mqtt_connection(self):
         return self._mqtt_connection
 
-    def _nonce_rpc_operation(self, request_topic, request_payload, request_payload_nonce_field, subscriptions):
-        # type: (str, PayloadObj, str, List[_NonceRpcSubscription]) -> Future
+    def _publish_operation(self, topic, payload):
+        # type(str, Optional[PayloadObj]) -> Future
         """
-        Performs a "Remote Procedure Call" style operation for an MQTT service,
-        where a "nonce" token is used to correlate requests with responses.
+        Performs a 'Publish' style operation for an MQTT service.
 
         Parameters:
-        request_topic - Topic for request message.
-        request_payload - Input object to be sent as JSON in the request message.
-        request_payload_nonce_field - Name of field in the request payload which contains the "nonce",
-                a unique string that will be copied to the response,
-                allowing the response to be correlated with this particular request.
-                If the field's value is empty, a uniqe value will be generated for this operation.
-        subscriptions - List of _NonceRpcSubscriptions, one for each possible response.
-
-        Returns a Future that will contain the outcome of the operation.
-        A response from a non-error topic becomes a valid result in the Future.
-        A response from an error topic becomes an Exception in the Future.
-        Any other exception that occurs as part of the RPC becomes an exception in the Future.
+        topic - The topic to publish this message to.
+        payload - (Optional) If set, the message will be a string of JSON, built from this object.
+                If unset, an empty message is sent.
         """
-
         future = Future() # type: Future
+        try:
+            def on_puback(packet_id):
+                future.set_result(None)
 
-        # generate a unique nonce, if none was contained in the payload
-        nonce_value = request_payload.get(request_payload_nonce_field)
-        if not nonce_value:
-            nonce_value = str(uuid4())
-            request_payload[request_payload_nonce_field] = nonce_value
+            payload_str = json.dumps(payload) if payload else ""
+            self.mqtt_connection.publish(
+                topic=topic,
+                payload=payload_str,
+                qos=mqtt.QoS.AtLeastOnce,
+                puback_callback=on_puback)
 
-        operation = _NonceRpcOperation(future, request_topic, json.dumps(request_payload), nonce_value, subscriptions)
-
-        # callback sends request when all subacks received
-        suback_counter = [] # type: List
-        def on_suback(packet_id):
-            # count subacks by popping an entry out of this list
-            if suback_counter:
-                suback_counter.pop()
-                if not suback_counter:
-                    # all subscriptions succeeded
-                    self.mqtt_connection.publish(operation.request_topic, operation.request_payload, 1)
-
-        with self._nonce_rpc_lock:
-            topics_to_subscribe_to = []
-            for sub in operation.subscriptions:
-                topic_entry = self._nonce_rpc_topics.get(sub.topic)
-                if not topic_entry:
-                    topics_to_subscribe_to.append(sub.topic)
-                    topic_entry = _NonceRpcTopicEntry(sub.response_payload_nonce_field)
-                    self._nonce_rpc_topics[sub.topic] = topic_entry
-
-                topic_entry.outstanding_operations[operation.nonce_value] = operation
-
-            if topics_to_subscribe_to:
-                suback_counter.extend(['suback'] * len(topics_to_subscribe_to))
-                for i in topics_to_subscribe_to:
-                    self.mqtt_connection.subscribe(i, 1, self._nonce_response_callback, on_suback)
-        # lock released
-
-        # if we're not waiting on any subscribes to complete, publish the request immediately
-        if not topics_to_subscribe_to:
-            self.mqtt_connection.publish(operation.request_topic, operation.request_payload, 1)
+        except Exception as e:
+            future.set_exception(e)
 
         return future
 
-    def _nonce_response_callback(self, topic, payload_str):
-        # type: (str, str) -> None
-        payload_obj = json.loads(payload_str)
-        operation = None
-        subscription = None
-        try:
-            with self._nonce_rpc_lock:
-                # find the corresponding operation
-                topic_entry = self._nonce_rpc_topics[topic]
-                nonce_value = payload_obj[topic_entry.nonce_field_name_in_response]
-                operation = topic_entry.outstanding_operations[nonce_value]
-
-                # operation found.
-                # remove it from all associated topics.
-                # unsubscribe from any topic that has no more outstanding operations.
-                topics_to_unsubscribe_from = [] # type: List
-
-                for sub in operation.subscriptions:
-                    if sub.topic == topic:
-                        subscription = sub
-                    topic_entry = self._nonce_rpc_topics[sub.topic]
-                    del topic_entry.outstanding_operations[nonce_value]
-                    if not topic_entry.outstanding_operations:
-                        del self._nonce_rpc_topics[sub.topic]
-                        topics_to_unsubscribe_from.append(sub.topic)
-
-                for i in topics_to_unsubscribe_from:
-                    self.mqtt_connection.unsubscribe(i)
-
-            # lock released
-            if subscription and operation:
-                result = subscription.response_payload_to_class_fn(payload_obj)
-                if isinstance(result, Exception):
-                    operation.future.set_exception(result)
-                else:
-                    operation.future.set_result(result)
-            else:
-                raise RuntimeError("Cannot determine response type")
-
-        except Exception as e:
-            if operation:
-                operation.future.set_exception(e)
-            else:
-                raise
-
-    def _fifo_rpc_operation(self, request_topic, request_payload, subscriptions):
-        # type: (str, Optional[PayloadObj], List[_FifoRpcSubscription]) -> Future
-        """
-        Performs a "Remote Procedure Call" style operation for an MQTT service,
-        where responses are correlated to requests on a first-in-first-out basis.
-
-        Parameters:
-        request_topic - Topic for request message.
-        request_payload - Input object to be sent as json string in request message.
-        subscriptions - List of _FifoRpcSubscriptions, one for each possible response.
-
-        Returns a Future that will contain the outcome of the operation.
-        A response from a non-error topic becomes a valid result in the Future.
-        A response from an error topic becomes an Exception in the Future.
-        Any other exception that occurs as part of the RPC becomes an exception in the Future.
-        """
-        future = Future() # type: Future
-        request_payload_str = json.dumps(request_payload) if request_payload else ""
-        operation = _FifoRpcOperation(future, request_topic, request_payload_str, subscriptions)
-
-        # callback sends request when all subacks received
-        suback_counter = [] # type: List
-        def on_suback(packet_id):
-            # count subacks by popping an entry out of this list
-            if suback_counter:
-                suback_counter.pop()
-                if not suback_counter:
-                    # all subscriptions succeeded
-                    self.mqtt_connection.publish(operation.request_topic, operation.request_payload, 1)
-
-        with self._fifo_rpc_lock:
-            topics_to_subscribe_to = []
-            for sub in operation.subscriptions:
-                topic_entry = self._fifo_rpc_topics.get(sub.topic)
-                if not topic_entry:
-                    topics_to_subscribe_to.append(sub.topic)
-                    topic_entry = _FifoRpcTopicEntry()
-                    self._fifo_rpc_topics[sub.topic] = topic_entry
-
-                topic_entry.outstanding_operations.append(operation)
-
-            if topics_to_subscribe_to:
-                suback_counter.extend(['suback'] * len(topics_to_subscribe_to))
-                for i in topics_to_subscribe_to:
-                    self.mqtt_connection.subscribe(i, 1, self._fifo_callback, on_suback)
-        # lock released.
-
-        # if we're not waiting on any subscribes to complete, publish the request immediately
-        if not topics_to_subscribe_to:
-            self.mqtt_connection.publish(operation.request_topic, operation.request_payload, 1)
-
-        return future
-
-    def _fifo_callback(self, topic, payload_str):
-        # type: (str, str) -> None
-        operation = None
-        subscription = None
-        try:
-            with self._fifo_rpc_lock:
-                # find the corresponding operation
-                topic_entry = self._fifo_rpc_topics[topic]
-                operation = topic_entry.outstanding_operations[0]
-
-                # operation found.
-                # remove it from all associated topics.
-                # unsubscribe from any topic that has no more outstanding operations.
-                topics_to_unsubscribe_from = []
-
-                for sub in operation.subscriptions:
-                    if sub.topic == topic:
-                        subscription = sub
-                    topic_entry = self._fifo_rpc_topics[sub.topic]
-                    topic_entry.outstanding_operations.remove(operation)
-                    if not topic_entry.outstanding_operations:
-                        del self._fifo_rpc_topics[sub.topic]
-                        topics_to_unsubscribe_from.append(sub.topic)
-
-                for i in topics_to_unsubscribe_from:
-                    self.mqtt_connection.unsubscribe(i)
-            # lock released
-
-            # sometimes the response is an empty string
-            try:
-                payload_obj = json.loads(payload_str)
-            except:
-                payload_obj = {}
-
-            if subscription and operation:
-                result = subscription.response_payload_to_class_fn(payload_obj)
-                if isinstance(result, Exception):
-                    operation.future.set_exception(result)
-                else:
-                    operation.future.set_result(result)
-            else:
-                raise RuntimeError("Cannot determine response type")
-
-        except Exception as e:
-            if operation:
-                operation.future.set_exception(e)
-            else:
-                raise
-
-    def _subscribe_operation(self, subscriptions):
-        # type: (List[_SubscriptionInfo]) -> Future
+    def _subscribe_operation(self, topic, callback, payload_to_class_fn):
+        # type: (str, Callable[[T], None], PayloadToClassFn) -> Future
         """
         Performs a 'Subscribe' style operation for an MQTT service.
+        Messages received from this topic are processed as JSON,
+        converted to the desired class by `payload_to_class_fn`,
+        then passed to `callback`.
 
         Parameters:
-        subscriptions - List of _SubscriptionInfos, one for each possible response.
+        topic - The topic to subscribe to.
+        callback - The callback to invoke when a message is received.
+                The callback should take one argument of the type
+                returned by payload_to_class_fn. The callback
+                is not expected to return a value.
+        payload_to_class_fn - A function which takes one argument,
+                a dict, and returns a class of the type expected by
+                `callback`. The dict comes from parsing the received
+                message as JSON.
 
-        Returns a Future that will contain None when all subscriptions have been acknowledged by the server.
+        Returns a Future whose result will be None when the subscription
+        is accepted by the server. If the subscription cannot be established,
+        the Future's result will be an exception.
         """
 
         future = Future() # type: Future
+        try:
+            def on_suback(packet_id, topic, qos):
+                future.set_result(None)
 
-        # callback informs Future when all subacks received
-        suback_counter = ['suback'] * len(subscriptions)
-        def on_suback(packet_id):
-            # count supacks by popping an entry out of this list
-            if suback_counter:
-                suback_counter.pop()
-                if not suback_counter:
-                    # all subscriptions succeeded
-                    future.set_result(None)
-
-        for sub in subscriptions:
-            def callback_wrapper(topic, json_payload):
+            def callback_wrapper(topic, payload_str):
                 try:
-                    payload = json.loads(json_payload)
-                    event = sub.payload_class.from_payload(payload)
-                    sub.callback(event)
+                    payload_obj = json.loads(payload_str)
+                    event = payload_to_class_fn(payload_obj)
                 except:
                     # can't deliver payload, invoke callback with None
-                    sub.callback(None)
+                    event = None
+                callback(event)
 
-            self.mqtt_connection.subscribe(sub.topic, 1, callback_wrapper, on_suback)
+            self.mqtt_connection.subscribe(
+                topic=topic,
+                qos=mqtt.QoS.AtLeastOnce,
+                callback=callback_wrapper,
+                suback_callback=on_suback)
+
+        except Exception as e:
+            future.set_exception(e)
 
         return future
-
-
-T = TypeVar('T')
-
-PayloadObj = Dict[str, Any]
-PayloadToClassFn = Callable[[PayloadObj], T]
-
-class _NonceRpcSubscription(object):
-    # type: Generic[T]
-    def __init__(self, topic, response_payload_to_class_fn, response_payload_nonce_field):
-        # type: (str, PayloadToClassFn, str) -> None
-        self.topic = topic # type: str
-        self.response_payload_to_class_fn = response_payload_to_class_fn # type: PayloadToClassFn
-        self.response_payload_nonce_field = response_payload_nonce_field # type: str
-
-class _NonceRpcOperation(object):
-    def __init__(self, future, request_topic, request_payload, nonce_value, subscriptions):
-        # type: (Future, str, str, str, List[_NonceRpcSubscription]) -> None
-        self.future = future # type: Future
-        self.request_topic = request_topic # type: str
-        self.request_payload = request_payload # type: str
-        self.nonce_value = nonce_value # type: str
-        self.subscriptions = subscriptions # type: List[_NonceRpcSubscription]
-
-class _FifoRpcSubscription(object):
-    # type: Generic[T]
-    def __init__(self, topic, response_payload_to_class_fn):
-        # type: (str, PayloadToClassFn) -> None
-        self.topic = topic # type: str
-        self.response_payload_to_class_fn = response_payload_to_class_fn # type: PayloadToClassFn
-
-class _FifoRpcOperation(object):
-    def __init__(self, future, request_topic, request_payload, subscriptions):
-        # type: (Future, str, str, List[_FifoRpcSubscription]) -> None
-        self.future = future # type: Future
-        self.request_topic = request_topic # type: str
-        self.request_payload = request_payload # type: str
-        self.subscriptions = subscriptions # type: List[_FifoRpcSubscription]
-
-class _NonceRpcTopicEntry(object):
-    def __init__(self, nonce_field_name_in_response):
-        # type: (str) -> None
-        self.nonce_field_name_in_response = nonce_field_name_in_response # type: str
-        self.outstanding_operations = {} # type: Dict[str, _NonceRpcOperation]
-
-class _FifoRpcTopicEntry(object):
-    def __init__(self):
-        # type() -> None
-        self.outstanding_operations = [] # type: List[_FifoRpcOperation]
-
-class _SubscriptionInfo(object):
-    # type: Generic[T]
-    def __init__(self, topic, callback, payload_class):
-        # type: (str, Callable[[T], None], Type[T]) -> None
-        self.topic = topic # type: str
-        self.callback = callback # type: Callable[[T], None]
-        self.payload_class = payload_class # Type[T]

--- a/awsiot/iotjobs.py
+++ b/awsiot/iotjobs.py
@@ -21,141 +21,353 @@ import typing
 
 class IotJobsClient(awsiot.MqttServiceClient):
 
-    def describe_job_execution(self, input):
+    def publish_describe(self, request):
         # type: (DescribeJobExecutionRequest) -> concurrent.futures.Future
-        if not input.job_id:
-            raise ValueError("input.job_id is required")
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-describejobexecution
 
-        request_topic = '$aws/things/{0.thing_name}/jobs/{0.job_id}/get'.format(input)
-        request_payload = input.to_payload()
-        request_payload_nonce_field = 'clientToken'
+        Parameters:
+        request - `DescribeJobExecutionRequest` instance.
 
-        response_subscriptions = [
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/get/accepted'.format(input),
-                response_payload_to_class_fn=DescribeJobExecutionResponse.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/get/rejected'.format(input),
-                response_payload_to_class_fn=RejectedError.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-        ]
+        Returns a concurrent.futures.Future, whose result will be None if the
+        request is successfully published. The Future's result will be an
+        exception if the request cannot be published.
+        """
+        if not request.job_id:
+            raise ValueError("request.job_id is required")
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
 
-        return self._nonce_rpc_operation(request_topic, request_payload, request_payload_nonce_field, response_subscriptions)
+        return self._publish_operation(
+            topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/get'.format(request),
+            payload=request.to_payload())
 
-    def get_job_executions_changed(self, input, handler):
-        # type: (GetJobExecutionsChangedRequest, JobExecutionsChangedEventsHandler) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
-
-        if not handler.on_job_executions_changed:
-            raise ValueError("handler.on_job_executions_changed is required")
-
-        subscriptions = [
-            awsiot._SubscriptionInfo(
-                topic='$aws/things/{0.thing_name}/jobs/notify'.format(input),
-                callback=handler.on_job_executions_changed,
-                payload_class=JobExecutionsChangedEvent,
-            ),
-        ]
-
-        return self._subscribe_operation(subscriptions)
-
-    def get_next_job_execution_changed(self, input, handler):
-        # type: (GetNextJobExecutionChangedRequest, NextJobExecutionChangedEventsHandler) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
-
-        if not handler.on_next_job_execution_changed:
-            raise ValueError("handler.on_next_job_execution_changed is required")
-
-        subscriptions = [
-            awsiot._SubscriptionInfo(
-                topic='$aws/things/{0.thing_name}/jobs/notify-next'.format(input),
-                callback=handler.on_next_job_execution_changed,
-                payload_class=NextJobExecutionChangedEvent,
-            ),
-        ]
-
-        return self._subscribe_operation(subscriptions)
-
-    def get_pending_job_executions(self, input):
+    def publish_get_pending(self, request):
         # type: (GetPendingJobExecutionsRequest) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-getpendingjobexecutions
 
-        request_topic = '$aws/things/{0.thing_name}/jobs/get'.format(input)
-        request_payload = input.to_payload()
-        request_payload_nonce_field = 'clientToken'
+        Parameters:
+        request - `GetPendingJobExecutionsRequest` instance.
 
-        response_subscriptions = [
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/jobs/get/accepted'.format(input),
-                response_payload_to_class_fn=GetPendingJobExecutionsResponse.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/jobs/get/rejected'.format(input),
-                response_payload_to_class_fn=RejectedError.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-        ]
+        Returns a concurrent.futures.Future, whose result will be None if the
+        request is successfully published. The Future's result will be an
+        exception if the request cannot be published.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
 
-        return self._nonce_rpc_operation(request_topic, request_payload, request_payload_nonce_field, response_subscriptions)
+        return self._publish_operation(
+            topic='$aws/things/{0.thing_name}/jobs/get'.format(request),
+            payload=request.to_payload())
 
-    def start_next_pending_job_execution(self, input):
+    def publish_start_next_pending(self, request):
         # type: (StartNextPendingJobExecutionRequest) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-startnextpendingjobexecution
 
-        request_topic = '$aws/things/{0.thing_name}/jobs/start-next'.format(input)
-        request_payload = input.to_payload()
-        request_payload_nonce_field = 'clientToken'
+        Parameters:
+        request - `StartNextPendingJobExecutionRequest` instance.
 
-        response_subscriptions = [
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/jobs/start-next/accepted'.format(input),
-                response_payload_to_class_fn=StartDescribeJobExecutionResponse.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/jobs/start-next/rejected'.format(input),
-                response_payload_to_class_fn=RejectedError.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-        ]
+        Returns a concurrent.futures.Future, whose result will be None if the
+        request is successfully published. The Future's result will be an
+        exception if the request cannot be published.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
 
-        return self._nonce_rpc_operation(request_topic, request_payload, request_payload_nonce_field, response_subscriptions)
+        return self._publish_operation(
+            topic='$aws/things/{0.thing_name}/jobs/start-next'.format(request),
+            payload=request.to_payload())
 
-    def update_job_execution(self, input):
+    def publish_update(self, request):
         # type: (UpdateJobExecutionRequest) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
-        if not input.job_id:
-            raise ValueError("input.job_id is required")
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-updatejobexecution
 
-        request_topic = '$aws/things/{0.thing_name}/jobs/{0.job_id}/update'.format(input)
-        request_payload = input.to_payload()
-        request_payload_nonce_field = 'clientToken'
+        Parameters:
+        request - `UpdateJobExecutionRequest` instance.
 
-        response_subscriptions = [
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/update/accepted'.format(input),
-                response_payload_to_class_fn=UpdateJobExecutionResponse.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/update/rejected'.format(input),
-                response_payload_to_class_fn=RejectedError.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-        ]
+        Returns a concurrent.futures.Future, whose result will be None if the
+        request is successfully published. The Future's result will be an
+        exception if the request cannot be published.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+        if not request.job_id:
+            raise ValueError("request.job_id is required")
 
-        return self._nonce_rpc_operation(request_topic, request_payload, request_payload_nonce_field, response_subscriptions)
+        return self._publish_operation(
+            topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/update'.format(request),
+            payload=request.to_payload())
+
+    def subscribe_to_describe_accepted(self, request, on_accepted):
+        # type: (DescribeJobExecutionSubscriptionRequest, typing.Callable[[DescribeJobExecutionResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-describejobexecution
+
+        Parameters:
+        request - `DescribeJobExecutionSubscriptionRequest` instance.
+        on_accepted - Callback to invoke each time the on_accepted event is received.
+                The callback should take 1 argument of type `DescribeJobExecutionResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+        if not request.job_id:
+            raise ValueError("request.job_id is required")
+
+        if not on_accepted:
+            raise ValueError("on_accepted is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/get/accepted'.format(request),
+            callback=on_accepted,
+            payload_to_class_fn=DescribeJobExecutionResponse.from_payload)
+
+    def subscribe_to_describe_rejected(self, request, on_rejected):
+        # type: (DescribeJobExecutionSubscriptionRequest, typing.Callable[[RejectedError], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-describejobexecution
+
+        Parameters:
+        request - `DescribeJobExecutionSubscriptionRequest` instance.
+        on_rejected - Callback to invoke each time the on_rejected event is received.
+                The callback should take 1 argument of type `RejectedError`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+        if not request.job_id:
+            raise ValueError("request.job_id is required")
+
+        if not on_rejected:
+            raise ValueError("on_rejected is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/get/rejected'.format(request),
+            callback=on_rejected,
+            payload_to_class_fn=RejectedError.from_payload)
+
+    def subscribe_to_executions_changed_events(self, request, on_job_executions_changed):
+        # type: (JobExecutionsChangedEventsSubscriptionRequest, typing.Callable[[JobExecutionsChangedEvent], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-jobexecutionschanged
+
+        Parameters:
+        request - `JobExecutionsChangedEventsSubscriptionRequest` instance.
+        on_job_executions_changed - Callback to invoke each time the on_job_executions_changed event is received.
+                The callback should take 1 argument of type `JobExecutionsChangedEvent`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_job_executions_changed:
+            raise ValueError("on_job_executions_changed is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/notify'.format(request),
+            callback=on_job_executions_changed,
+            payload_to_class_fn=JobExecutionsChangedEvent.from_payload)
+
+    def subscribe_to_get_pending_accepted(self, request, on_accepted):
+        # type: (GetPendingJobExecutionsSubscriptionRequest, typing.Callable[[GetPendingJobExecutionsResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-getpendingjobexecutions
+
+        Parameters:
+        request - `GetPendingJobExecutionsSubscriptionRequest` instance.
+        on_accepted - Callback to invoke each time the on_accepted event is received.
+                The callback should take 1 argument of type `GetPendingJobExecutionsResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_accepted:
+            raise ValueError("on_accepted is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/get/accepted'.format(request),
+            callback=on_accepted,
+            payload_to_class_fn=GetPendingJobExecutionsResponse.from_payload)
+
+    def subscribe_to_get_pending_rejected(self, request, on_rejected):
+        # type: (GetPendingJobExecutionsSubscriptionRequest, typing.Callable[[RejectedError], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-getpendingjobexecutions
+
+        Parameters:
+        request - `GetPendingJobExecutionsSubscriptionRequest` instance.
+        on_rejected - Callback to invoke each time the on_rejected event is received.
+                The callback should take 1 argument of type `RejectedError`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_rejected:
+            raise ValueError("on_rejected is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/get/rejected'.format(request),
+            callback=on_rejected,
+            payload_to_class_fn=RejectedError.from_payload)
+
+    def subscribe_to_next_changed_events(self, request, on_next_job_execution_changed):
+        # type: (NextJobExecutionChangedEventsSubscriptionRequest, typing.Callable[[NextJobExecutionChangedEvent], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-nextjobexecutionchanged
+
+        Parameters:
+        request - `NextJobExecutionChangedEventsSubscriptionRequest` instance.
+        on_next_job_execution_changed - Callback to invoke each time the on_next_job_execution_changed event is received.
+                The callback should take 1 argument of type `NextJobExecutionChangedEvent`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_next_job_execution_changed:
+            raise ValueError("on_next_job_execution_changed is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/notify-next'.format(request),
+            callback=on_next_job_execution_changed,
+            payload_to_class_fn=NextJobExecutionChangedEvent.from_payload)
+
+    def subscribe_to_start_next_pending_accepted(self, request, on_accepted):
+        # type: (StartNextPendingJobExecutionSubscriptionRequest, typing.Callable[[StartDescribeJobExecutionResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-startnextpendingjobexecution
+
+        Parameters:
+        request - `StartNextPendingJobExecutionSubscriptionRequest` instance.
+        on_accepted - Callback to invoke each time the on_accepted event is received.
+                The callback should take 1 argument of type `StartDescribeJobExecutionResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_accepted:
+            raise ValueError("on_accepted is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/start-next/accepted'.format(request),
+            callback=on_accepted,
+            payload_to_class_fn=StartDescribeJobExecutionResponse.from_payload)
+
+    def subscribe_to_start_next_pending_rejected(self, request, on_rejected):
+        # type: (StartNextPendingJobExecutionSubscriptionRequest, typing.Callable[[RejectedError], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-startnextpendingjobexecution
+
+        Parameters:
+        request - `StartNextPendingJobExecutionSubscriptionRequest` instance.
+        on_rejected - Callback to invoke each time the on_rejected event is received.
+                The callback should take 1 argument of type `RejectedError`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_rejected:
+            raise ValueError("on_rejected is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/start-next/rejected'.format(request),
+            callback=on_rejected,
+            payload_to_class_fn=RejectedError.from_payload)
+
+    def subscribe_to_update_accepted(self, request, on_accepted):
+        # type: (UpdateJobExecutionSubscriptionRequest, typing.Callable[[UpdateJobExecutionResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-updatejobexecution
+
+        Parameters:
+        request - `UpdateJobExecutionSubscriptionRequest` instance.
+        on_accepted - Callback to invoke each time the on_accepted event is received.
+                The callback should take 1 argument of type `UpdateJobExecutionResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+        if not request.job_id:
+            raise ValueError("request.job_id is required")
+
+        if not on_accepted:
+            raise ValueError("on_accepted is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/update/accepted'.format(request),
+            callback=on_accepted,
+            payload_to_class_fn=UpdateJobExecutionResponse.from_payload)
+
+    def subscribe_to_update_rejected(self, request, on_rejected):
+        # type: (UpdateJobExecutionSubscriptionRequest, typing.Callable[[RejectedError], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-updatejobexecution
+
+        Parameters:
+        request - `UpdateJobExecutionSubscriptionRequest` instance.
+        on_rejected - Callback to invoke each time the on_rejected event is received.
+                The callback should take 1 argument of type `RejectedError`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+        if not request.job_id:
+            raise ValueError("request.job_id is required")
+
+        if not on_rejected:
+            raise ValueError("on_rejected is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/jobs/{0.job_id}/update/rejected'.format(request),
+            callback=on_rejected,
+            payload_to_class_fn=RejectedError.from_payload)
 
 class DescribeJobExecutionRequest(object):
     def __init__(self, client_token=None, execution_number=None, include_job_document=None, job_id=None, thing_name=None):
@@ -199,14 +411,10 @@ class DescribeJobExecutionResponse(object):
             new.timestamp = datetime.datetime.fromtimestamp(val)
         return new
 
-class GetJobExecutionsChangedRequest(object):
-    def __init__(self, thing_name=None):
-        # type: (typing.Optional[str]) -> None
-        self.thing_name = thing_name # type: typing.Optional[str]
-
-class GetNextJobExecutionChangedRequest(object):
-    def __init__(self, thing_name=None):
-        # type: (typing.Optional[str]) -> None
+class DescribeJobExecutionSubscriptionRequest(object):
+    def __init__(self, job_id=None, thing_name=None):
+        # type: (typing.Optional[str], typing.Optional[str]) -> None
+        self.job_id = job_id # type: typing.Optional[str]
         self.thing_name = thing_name # type: typing.Optional[str]
 
 class GetPendingJobExecutionsRequest(object):
@@ -247,6 +455,11 @@ class GetPendingJobExecutionsResponse(object):
         if val:
             new.timestamp = datetime.datetime.fromtimestamp(val)
         return new
+
+class GetPendingJobExecutionsSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
 
 class JobExecutionData(object):
     def __init__(self, execution_number=None, job_document=None, job_id=None, last_updated_at=None, queued_at=None, started_at=None, status=None, thing_name=None, version_number=None):
@@ -360,9 +573,10 @@ class JobExecutionsChangedEvent(object):
             new.timestamp = datetime.datetime.fromtimestamp(val)
         return new
 
-class JobExecutionsChangedEventsHandler:
-    def __init__(self):
-        self.on_job_executions_changed = None # type: typing.Callable[[JobExecutionsChangedEvent], None]
+class JobExecutionsChangedEventsSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
 
 class JobExecutionsChangedJobs(object):
     def __init__(self, job_execution_state=None):
@@ -396,11 +610,12 @@ class NextJobExecutionChangedEvent(object):
             new.timestamp = datetime.datetime.fromtimestamp(val)
         return new
 
-class NextJobExecutionChangedEventsHandler:
-    def __init__(self):
-        self.on_next_job_execution_changed = None # type: typing.Callable[[NextJobExecutionChangedEvent], None]
+class NextJobExecutionChangedEventsSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
 
-class RejectedError(Exception):
+class RejectedError(object):
     def __init__(self, client_token=None, code=None, execution_state=None, message=None, timestamp=None):
         # type: (typing.Optional[str], typing.Optional[str], typing.Optional[JobExecutionState], typing.Optional[str], typing.Optional[datetime.datetime]) -> None
         self.client_token = client_token # type: typing.Optional[str]
@@ -471,6 +686,11 @@ class StartNextPendingJobExecutionRequest(object):
             payload['stepTimeoutInMinutes'] = self.step_timeout_in_minutes
         return payload
 
+class StartNextPendingJobExecutionSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
+
 class UpdateJobExecutionRequest(object):
     def __init__(self, client_token=None, execution_number=None, expected_version=None, include_job_document=None, include_job_execution_state=None, job_id=None, status=None, status_details=None, thing_name=None):
         # type: (typing.Optional[str], typing.Optional[int], typing.Optional[int], typing.Optional[bool], typing.Optional[bool], typing.Optional[str], typing.Optional[str], typing.Optional[typing.Dict[str, str]], typing.Optional[str]) -> None
@@ -528,4 +748,10 @@ class UpdateJobExecutionResponse(object):
         if val:
             new.timestamp = datetime.datetime.fromtimestamp(val)
         return new
+
+class UpdateJobExecutionSubscriptionRequest(object):
+    def __init__(self, job_id=None, thing_name=None):
+        # type: (typing.Optional[str], typing.Optional[str]) -> None
+        self.job_id = job_id # type: typing.Optional[str]
+        self.thing_name = thing_name # type: typing.Optional[str]
 

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -21,105 +21,270 @@ import typing
 
 class IotShadowClient(awsiot.MqttServiceClient):
 
-    def delete_shadow(self, input):
+    def publish_delete(self, request):
         # type: (DeleteShadowRequest) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#delete-pub-sub-topic
 
-        request_topic = '$aws/things/{0.thing_name}/shadow/delete'.format(input)
-        request_payload = None
-        response_subscriptions = [
-            awsiot._FifoRpcSubscription(
-                topic='$aws/things/{0.thing_name}/shadow/delete/accepted'.format(input),
-                response_payload_to_class_fn=DeleteShadowResponse.from_payload,
-            ),
-            awsiot._FifoRpcSubscription(
-                topic='$aws/things/{0.thing_name}/shadow/delete/rejected'.format(input),
-                response_payload_to_class_fn=ErrorResponse.from_payload,
-            ),
-        ]
+        Parameters:
+        request - `DeleteShadowRequest` instance.
 
-        return self._fifo_rpc_operation(request_topic, request_payload, response_subscriptions)
+        Returns a concurrent.futures.Future, whose result will be None if the
+        request is successfully published. The Future's result will be an
+        exception if the request cannot be published.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
 
-    def get_shadow(self, input):
+        return self._publish_operation(
+            topic='$aws/things/{0.thing_name}/shadow/delete'.format(request),
+            payload=None)
+
+    def publish_get(self, request):
         # type: (GetShadowRequest) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#get-pub-sub-topic
 
-        request_topic = '$aws/things/{0.thing_name}/shadow/get'.format(input)
-        request_payload = None
-        response_subscriptions = [
-            awsiot._FifoRpcSubscription(
-                topic='$aws/things/{0.thing_name}/shadow/get/accepted'.format(input),
-                response_payload_to_class_fn=GetShadowResponse.from_payload,
-            ),
-            awsiot._FifoRpcSubscription(
-                topic='$aws/things/{0.thing_name}/shadow/get/rejected'.format(input),
-                response_payload_to_class_fn=ErrorResponse.from_payload,
-            ),
-        ]
+        Parameters:
+        request - `GetShadowRequest` instance.
 
-        return self._fifo_rpc_operation(request_topic, request_payload, response_subscriptions)
+        Returns a concurrent.futures.Future, whose result will be None if the
+        request is successfully published. The Future's result will be an
+        exception if the request cannot be published.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
 
-    def subscribe_to_shadow_deltas(self, input, handler):
-        # type: (SubscribeToShadowDeltasRequest, ShadowDeltaEventsHandler) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
+        return self._publish_operation(
+            topic='$aws/things/{0.thing_name}/shadow/get'.format(request),
+            payload=None)
 
-        if not handler.on_delta:
-            raise ValueError("handler.on_delta is required")
-
-        subscriptions = [
-            awsiot._SubscriptionInfo(
-                topic='$aws/things/{0.thing_name}/shadow/update/delta'.format(input),
-                callback=handler.on_delta,
-                payload_class=ShadowDeltaEvent,
-            ),
-        ]
-
-        return self._subscribe_operation(subscriptions)
-
-    def subscribe_to_shadow_updates(self, input, handler):
-        # type: (SubscribeToShadowUpdatesRequest, ShadowUpdateEventsHandler) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
-
-        if not handler.on_updated:
-            raise ValueError("handler.on_updated is required")
-
-        subscriptions = [
-            awsiot._SubscriptionInfo(
-                topic='$aws/things/{0.thing_name}/shadow/update/documents'.format(input),
-                callback=handler.on_updated,
-                payload_class=ShadowUpdateEvent,
-            ),
-        ]
-
-        return self._subscribe_operation(subscriptions)
-
-    def update_shadow(self, input):
+    def publish_update(self, request):
         # type: (UpdateShadowRequest) -> concurrent.futures.Future
-        if not input.thing_name:
-            raise ValueError("input.thing_name is required")
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#update-pub-sub-topic
 
-        request_topic = '$aws/things/{0.thing_name}/shadow/update'.format(input)
-        request_payload = input.to_payload()
-        request_payload_nonce_field = 'clientToken'
+        Parameters:
+        request - `UpdateShadowRequest` instance.
 
-        response_subscriptions = [
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/shadow/update/accepted'.format(input),
-                response_payload_to_class_fn=UpdateShadowResponse.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-            awsiot._NonceRpcSubscription(
-                topic='$aws/things/{0.thing_name}/shadow/update/rejected'.format(input),
-                response_payload_to_class_fn=ErrorResponse.from_payload,
-                response_payload_nonce_field='clientToken',
-            ),
-        ]
+        Returns a concurrent.futures.Future, whose result will be None if the
+        request is successfully published. The Future's result will be an
+        exception if the request cannot be published.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
 
-        return self._nonce_rpc_operation(request_topic, request_payload, request_payload_nonce_field, response_subscriptions)
+        return self._publish_operation(
+            topic='$aws/things/{0.thing_name}/shadow/update'.format(request),
+            payload=request.to_payload())
+
+    def subscribe_to_delete_accepted(self, request, on_accepted):
+        # type: (DeleteShadowSubscriptionRequest, typing.Callable[[DeleteShadowResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#delete-accepted-pub-sub-topic
+
+        Parameters:
+        request - `DeleteShadowSubscriptionRequest` instance.
+        on_accepted - Callback to invoke each time the on_accepted event is received.
+                The callback should take 1 argument of type `DeleteShadowResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_accepted:
+            raise ValueError("on_accepted is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/shadow/delete/accepted'.format(request),
+            callback=on_accepted,
+            payload_to_class_fn=DeleteShadowResponse.from_payload)
+
+    def subscribe_to_delete_rejected(self, request, on_rejected):
+        # type: (DeleteShadowSubscriptionRequest, typing.Callable[[ErrorResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#delete-rejected-pub-sub-topic
+
+        Parameters:
+        request - `DeleteShadowSubscriptionRequest` instance.
+        on_rejected - Callback to invoke each time the on_rejected event is received.
+                The callback should take 1 argument of type `ErrorResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_rejected:
+            raise ValueError("on_rejected is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/shadow/delete/rejected'.format(request),
+            callback=on_rejected,
+            payload_to_class_fn=ErrorResponse.from_payload)
+
+    def subscribe_to_delta_events(self, request, on_delta):
+        # type: (ShadowDeltaEventsSubscriptionRequest, typing.Callable[[ShadowDeltaEvent], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#update-delta-pub-sub-topic
+
+        Parameters:
+        request - `ShadowDeltaEventsSubscriptionRequest` instance.
+        on_delta - Callback to invoke each time the on_delta event is received.
+                The callback should take 1 argument of type `ShadowDeltaEvent`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_delta:
+            raise ValueError("on_delta is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/shadow/update/delta'.format(request),
+            callback=on_delta,
+            payload_to_class_fn=ShadowDeltaEvent.from_payload)
+
+    def subscribe_to_get_accepted(self, request, on_accepted):
+        # type: (GetShadowSubscriptionRequest, typing.Callable[[GetShadowResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#get-accepted-pub-sub-topic
+
+        Parameters:
+        request - `GetShadowSubscriptionRequest` instance.
+        on_accepted - Callback to invoke each time the on_accepted event is received.
+                The callback should take 1 argument of type `GetShadowResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_accepted:
+            raise ValueError("on_accepted is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/shadow/get/accepted'.format(request),
+            callback=on_accepted,
+            payload_to_class_fn=GetShadowResponse.from_payload)
+
+    def subscribe_to_get_rejected(self, request, on_rejected):
+        # type: (GetShadowSubscriptionRequest, typing.Callable[[ErrorResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#get-rejected-pub-sub-topic
+
+        Parameters:
+        request - `GetShadowSubscriptionRequest` instance.
+        on_rejected - Callback to invoke each time the on_rejected event is received.
+                The callback should take 1 argument of type `ErrorResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_rejected:
+            raise ValueError("on_rejected is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/shadow/get/rejected'.format(request),
+            callback=on_rejected,
+            payload_to_class_fn=ErrorResponse.from_payload)
+
+    def subscribe_to_update_accepted(self, request, on_accepted):
+        # type: (UpdateShadowSubscriptionRequest, typing.Callable[[UpdateShadowResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#update-accepted-pub-sub-topic
+
+        Parameters:
+        request - `UpdateShadowSubscriptionRequest` instance.
+        on_accepted - Callback to invoke each time the on_accepted event is received.
+                The callback should take 1 argument of type `UpdateShadowResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_accepted:
+            raise ValueError("on_accepted is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/shadow/update/accepted'.format(request),
+            callback=on_accepted,
+            payload_to_class_fn=UpdateShadowResponse.from_payload)
+
+    def subscribe_to_update_events(self, request, on_updated):
+        # type: (ShadowUpdateEventsSubscriptionRequest, typing.Callable[[ShadowUpdateEvent], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#update-documents-pub-sub-topic
+
+        Parameters:
+        request - `ShadowUpdateEventsSubscriptionRequest` instance.
+        on_updated - Callback to invoke each time the on_updated event is received.
+                The callback should take 1 argument of type `ShadowUpdateEvent`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_updated:
+            raise ValueError("on_updated is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/shadow/update/documents'.format(request),
+            callback=on_updated,
+            payload_to_class_fn=ShadowUpdateEvent.from_payload)
+
+    def subscribe_to_update_rejected(self, request, on_rejected):
+        # type: (UpdateShadowSubscriptionRequest, typing.Callable[[ErrorResponse], None]) -> concurrent.futures.Future
+        """
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#update-rejected-pub-sub-topic
+
+        Parameters:
+        request - `UpdateShadowSubscriptionRequest` instance.
+        on_rejected - Callback to invoke each time the on_rejected event is received.
+                The callback should take 1 argument of type `ErrorResponse`.
+                The callback is not expected to return anything.
+
+        Returns a concurrent.futures.Future, whose result will be None if the
+        subscription is successful. The Future's result will be an exception
+        if the subscription is unsuccessful.
+        """
+        if not request.thing_name:
+            raise ValueError("request.thing_name is required")
+
+        if not on_rejected:
+            raise ValueError("on_rejected is required")
+
+        return self._subscribe_operation(
+            topic='$aws/things/{0.thing_name}/shadow/update/rejected'.format(request),
+            callback=on_rejected,
+            payload_to_class_fn=ErrorResponse.from_payload)
 
 class DeleteShadowRequest(object):
     def __init__(self, thing_name=None):
@@ -144,7 +309,12 @@ class DeleteShadowResponse(object):
             new.version = val
         return new
 
-class ErrorResponse(Exception):
+class DeleteShadowSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
+
+class ErrorResponse(object):
     def __init__(self, client_token=None, code=None, message=None, timestamp=None):
         # type: (typing.Optional[str], typing.Optional[int], typing.Optional[str], typing.Optional[datetime.datetime]) -> None
         self.client_token = client_token # type: typing.Optional[str]
@@ -201,6 +371,11 @@ class GetShadowResponse(object):
             new.version = val
         return new
 
+class GetShadowSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
+
 class ShadowDeltaEvent(object):
     def __init__(self, metadata=None, state=None, timestamp=None, version=None):
         # type: (typing.Optional[typing.Dict[str, typing.Any]], typing.Optional[typing.Dict[str, typing.Any]], typing.Optional[datetime.datetime], typing.Optional[int]) -> None
@@ -227,9 +402,10 @@ class ShadowDeltaEvent(object):
             new.version = val
         return new
 
-class ShadowDeltaEventsHandler:
-    def __init__(self):
-        self.on_delta = None # type: typing.Callable[[ShadowDeltaEvent], None]
+class ShadowDeltaEventsSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
 
 class ShadowMetadata(object):
     def __init__(self, desired=None, reported=None):
@@ -320,9 +496,10 @@ class ShadowUpdateEvent(object):
             new.timestamp = datetime.datetime.fromtimestamp(val)
         return new
 
-class ShadowUpdateEventsHandler:
-    def __init__(self):
-        self.on_updated = None # type: typing.Callable[[ShadowUpdateEvent], None]
+class ShadowUpdateEventsSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
 
 class ShadowUpdateSnapshot(object):
     def __init__(self, metadata=None, state=None, version=None):
@@ -345,16 +522,6 @@ class ShadowUpdateSnapshot(object):
         if val:
             new.version = val
         return new
-
-class SubscribeToShadowDeltasRequest(object):
-    def __init__(self, thing_name=None):
-        # type: (typing.Optional[str]) -> None
-        self.thing_name = thing_name # type: typing.Optional[str]
-
-class SubscribeToShadowUpdatesRequest(object):
-    def __init__(self, thing_name=None):
-        # type: (typing.Optional[str]) -> None
-        self.thing_name = thing_name # type: typing.Optional[str]
 
 class UpdateShadowRequest(object):
     def __init__(self, client_token=None, state=None, thing_name=None, version=None):
@@ -404,4 +571,9 @@ class UpdateShadowResponse(object):
         if val:
             new.version = val
         return new
+
+class UpdateShadowSubscriptionRequest(object):
+    def __init__(self, thing_name=None):
+        # type: (typing.Optional[str]) -> None
+        self.thing_name = thing_name # type: typing.Optional[str]
 

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -99,20 +99,22 @@ if __name__ == '__main__':
     tls_context = io.ClientTlsContext(tls_options)
 
     mqtt_client = mqtt.Client(client_bootstrap, tls_context)
-    mqtt_connection = mqtt.Connection(mqtt_client, 'samples_client_id')
 
-    # Connect
+    # Create connection
     port = 443 if io.is_alpn_available() else 8883
     print("Connecting to {} on port {}...".format(args.endpoint, port))
+    mqtt_connection = mqtt.Connection(
+        client=mqtt_client,
+        client_id='samples_client_id')
     mqtt_connection.connect(
-            host_name = args.endpoint,
-            port = port,
-            on_connect=on_connected,
-            on_disconnect=on_disconnected,
-            use_websocket=False,
-            alpn=None,
-            clean_session=True,
-            keep_alive=6000)
+        host_name = args.endpoint,
+        port = port,
+        on_connect=on_connected,
+        on_disconnect=on_disconnected,
+        use_websocket=False,
+        alpn=None,
+        clean_session=True,
+        keep_alive=6000)
 
     connected_event.wait()
     connected_code = connected_results['return_code']


### PR DESCRIPTION
Services are now modeled as raw publish and subscribe operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
