### PR TITLE
RPC handler

### DIFF
--- a/awsiot/rpc.py
+++ b/awsiot/rpc.py
@@ -1,0 +1,578 @@
+# Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from aws_crt import mqtt
+from awsiot import MqttServiceClient, iotshadow, iotjobs
+from concurrent.futures import Future
+from functools import partial
+from threading import RLock
+from typing import Callable, Dict
+from uuid import uuid1
+
+
+CLIENT_TOKEN_ATTR = "client_token"
+
+
+class _MqttRpcServiceClient(object):
+    """
+    This class hides the complexity of performing RPCs over the MQTT's
+    publish/subscribe architecture.
+    """
+
+    def __init__(self, mqtt_service_client):
+        self._lock = RLock()  # type: RLock
+        self._topic_entries = {}  # type: Dict[str, _RpcTopicEntry]
+        self._mqtt_service_client = mqtt_service_client  # type: MqttServiceClient
+
+    def unsubscribe(self, topic):
+        # type: (str) -> Future
+        """
+        Tell the MQTT server to stop sending messages to this topic.
+
+        Returns a `Future` whose result will be `None` when the server
+        has acknowledged the unsubscribe.
+        """
+        return self._mqtt_service_client.unsubscribe(topic)
+
+    def _start_rpc(
+        self, pub_op, pub_request, sub_accepted_op, sub_rejected_op, sub_request
+    ):
+        future = Future()
+
+        # Since this function returns a future, stuff any exceptions in there.
+        try:
+            for slot in sub_request.__slots__:
+                if not getattr(sub_request, slot, None):
+                    raise ValueError("request.{} is required".format(slot))
+
+            topic_key = "{} {}".format(pub_op.__name__, repr(sub_request))
+
+            uses_client_token = CLIENT_TOKEN_ATTR in pub_request.__slots__
+            if uses_client_token:
+                setattr(pub_request, CLIENT_TOKEN_ATTR, str(uuid1()))
+
+            rpc_operation = _RpcOperation(pub_op, pub_request, topic_key, future)
+
+        except Exception as e:
+            future.set_exception(e)
+            return future
+
+        # These are things we might do once lock is released
+        should_publish_now = False
+        suback_futures_needing_callbacks = []
+        fail_now_reason = None
+
+        # Hold lock while mutating topic entries.
+        with self._lock:
+            try:
+                entry = self._topic_entries.get(topic_key)
+                if entry:
+                    # Entry already exists, so subscriptions have already
+                    # been issued. If pending subscriptions have completed,
+                    # publish the request immediately.
+                    entry.pending_operations.append(rpc_operation)
+                    if not entry.pending_suback_futures:
+                        should_publish_now = True
+
+                else:
+                    # Create entry and subscribe to its response topics.
+                    entry = _RpcTopicEntry(uses_client_token)
+                    entry.pending_operations.append(rpc_operation)
+                    self._topic_entries[rpc_operation.topic_key] = entry
+                    for sub_op_i in (sub_accepted_op, sub_rejected_op):
+                        sub_future, sub_topic = sub_op_i(
+                            sub_request, partial(self._on_response, topic_key)
+                        )
+                        suback_futures_needing_callbacks.append(sub_future)
+                        entry.pending_suback_futures.append(sub_future)
+                        entry.subscribed_topics.append(sub_topic)
+
+            except Exception as e:
+                self._remove_rpc(rpc_operation)
+                fail_now_reason = e
+
+        # With lock released
+        if should_publish_now:
+            self._publish_with_lock_released(rpc_operation)
+
+        for suback_i in suback_futures_needing_callbacks:
+            suback_i.add_done_callback(partial(self._on_suback, topic_key))
+
+        if fail_now_reason is not None:
+            self._complete_rpc_with_lock_released(rpc_operation, fail_now_reason)
+
+        return future
+
+    def _on_suback(self, topic_key, suback_future):
+        operations_to_complete = []
+        operations_to_publish = []
+
+        with self._lock:
+            try:
+                entry = self._topic_entries[topic_key]
+                entry.pending_suback_futures.remove(suback_future)
+            except (KeyError, ValueError):
+                # Do nothing, this suback must correspond to some
+                # old entry that's already been dealt with.
+                return
+
+            if suback_future.exception():
+                # Couldn't subscribe. Remove the topic entry and
+                # mark all its pending operations as failures.
+                operations_to_complete.extend(entry.pending_operations)
+                for operation_i in operations_to_complete:
+                    self._remove_rpc(operation_i)
+            else:
+                # Subscribed. If this was the last pending subscription,
+                # all the operations can publish their requests now.
+                if not entry.pending_suback_futures:
+                    operations_to_publish.extend(entry.pending_operations)
+
+        # With lock released
+        for operation_i in operations_to_complete:
+            self._complete_rpc_with_lock_released(operation_i, suback_future)
+
+        for operation_i in operations_to_publish:
+            self._publish_with_lock_released(operation_i)
+
+    def _publish_with_lock_released(self, rpc_operation):
+        """Should not be called while holding the lock"""
+        try:
+            pub_future = rpc_operation.pub_op(rpc_operation.pub_request)
+            pub_future.add_done_callback(partial(self._on_puback, rpc_operation))
+        except Exception as e:
+            self._remove_rpc(rpc_operation)
+            self._complete_rpc_with_lock_released(rpc_operation, e)
+
+    def _on_puback(self, rpc_operation, pub_future):
+        if pub_future.exception():
+            self._remove_rpc(rpc_operation)
+            self._complete_rpc_with_lock_released(rpc_operation, pub_future)
+
+    def _on_response(self, topic_key, response):
+        corresponding_operation = None
+        with self._lock:
+            entry = self._topic_entries.get(topic_key)
+            if entry:
+                if entry.uses_client_token:
+                    # Find operation with matching token
+                    response_token = getattr(response, CLIENT_TOKEN_ATTR, None)
+                    if response_token:
+                        for operation_i in entry.pending_operations:
+                            if operation_i.client_token() == response_token:
+                                corresponding_operation = operation_i
+                                break
+                else:
+                    # Assume response is to the oldest operation
+                    corresponding_operation = entry.pending_operations[0]
+
+            if corresponding_operation:
+                self._remove_rpc(corresponding_operation)
+
+        # With lock released
+        if corresponding_operation:
+            self._complete_rpc_with_lock_released(corresponding_operation, response)
+
+    def _remove_rpc(self, rpc_operation):
+        """
+        Remove operation from its topic entry. Once all operations in an entry
+        are complete, the entry is removed its topics are unsubscribed from.
+        """
+        with self._lock:
+            entry = self._topic_entries.get(rpc_operation.topic_key)
+            if entry:
+                # Remove operation from the entry.
+                try:
+                    entry.pending_operations.remove(rpc_operation)
+                except ValueError:
+                    return
+
+                # If no operations remain in the entry,
+                # remove the entry and unsubscribe from its topics.
+                if not entry.pending_operations:
+                    del self._topic_entries[rpc_operation.topic_key]
+                    for topic in entry.subscribed_topics:
+                        # If unsubscribe fails it just means we weren't
+                        # subscribed to begin with.
+                        try:
+                            self.unsubscribe(topic)
+                        except:
+                            pass
+
+    def _complete_rpc_with_lock_released(self, operation, result):
+        """
+        Set the result of the operation. This should be called with the lock
+        released, to avoid the possibility of callbacks firing which set up a
+        chain of events resulting in deadlock.
+        """
+
+        # If result is a Future, extract its contents
+        if isinstance(result, Future):
+            try:
+                result = result.result()
+            except Exception as e:
+                result = e
+
+        # Let subclasses transform results
+        result = self._transform_result(result)
+
+        if not operation.future.done():
+            if isinstance(result, Exception):
+                operation.future.set_exception(result)
+            else:
+                operation.future.set_result(result)
+
+    def _transform_result(self, result):
+        return result
+
+
+class _RpcTopicEntry(object):
+    """A set of _RpcOperations which are subscribed to identical topics."""
+
+    __slots__ = (
+        "pending_operations",
+        "subscribed_topics",
+        "pending_suback_futures",
+        "uses_client_token",
+    )
+
+    def __init__(self, uses_client_token):
+        self.pending_operations = []  # type: List[_RpcOperation]
+        self.subscribed_topics = []  # type: List[str]
+        self.pending_suback_futures = []  # type: List[Future]
+        self.uses_client_token = uses_client_token  # type: bool
+
+
+class _RpcOperation(object):
+    """An operation within an _RpcTopicEntry."""
+
+    __slots__ = ("pub_op", "pub_request", "topic_key", "future")
+
+    def __init__(self, pub_op, pub_request, topic_key, future):
+        self.pub_op = pub_op
+        self.pub_request = pub_request
+        self.topic_key = topic_key  # type: str
+        self.future = future  # type: Future
+
+    def client_token(self):
+        return getattr(self.pub_request, CLIENT_TOKEN_ATTR, None)
+
+
+class JobsErrorResponse(Exception):
+    """Exception for when the server responds with a rejection of the request."""
+    def __init__(self, response):
+        self.response = response  # type: iotjobs.RejectedError
+
+
+class IotJobsRpcClient(_MqttRpcServiceClient):
+    """
+    This alternative to the `IoTJobsClient` handles the complexity of
+    performing RPCs (remote procedure calls) over the MQTT's
+    publish/subscribe architecture.
+    """
+
+    def __init__(self, mqtt_connection):
+        # type: (mqtt.Connection) -> None
+        super(IotJobsRpcClient, self).__init__(iotjobs.IotJobsClient(mqtt_connection))
+        self._jobs_client = self._mqtt_service_client  # type: iotshadow.IotJobsClient
+
+    def describe_job_execution(self, request):
+        # type(iotjobs.DescribeJobExecutionRequest) -> Future
+        """
+        Gets detailed information about a job execution.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-describejobexecution
+
+        Parameters:
+        request - `DescribeJobExecutionRequest` instance.
+
+        Returns a `Future` which will contain a result of `DescribeJobExecutionResponse`
+        if the operation succeeds, or an exception if the operation fails.
+        """
+        return self._start_rpc(
+            pub_op=self._jobs_client.publish_describe_job_execution,
+            pub_request=request,
+            sub_accepted_op=self._jobs_client.subscribe_to_describe_job_execution_accepted,
+            sub_rejected_op=self._jobs_client.subscribe_to_describe_job_execution_rejected,
+            sub_request=iotjobs.DescribeJobExecutionSubscriptionRequest(
+                job_id=request.job_id, thing_name=request.thing_name
+            ),
+        )
+
+    def get_pending_job_executions(self, request):
+        # type(iotjobs.GetPendingJobExecutionsRequest) -> Future
+        """
+        Gets the list of all jobs for a thing that are not in a terminal state.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-getpendingjobexecutions
+
+        Parameters:
+        request - `GetPendingJobExecutionsRequest` instance.
+
+        Returns a `Future` which will contain a result of `GetPendingJobExecutionsResponse`
+        if the operation succeeds, or an exception if the operation fails.
+        """
+        return self._start_rpc(
+            pub_op=self._jobs_client.publish_get_pending_job_executions,
+            pub_request=request,
+            sub_accepted_op=self._jobs_client.subscribe_to_get_pending_job_executions_accepted,
+            sub_rejected_op=self._jobs_client.subscribe_to_get_pending_job_executions_rejected,
+            sub_request=iotjobs.GetPendingJobExecutionsSubscriptionRequest(
+                thing_name=request.thing_name
+            ),
+        )
+
+    def start_next_pending_job_execution(self, request):
+        # type(iotjobs.StartNextPendingJobExecutionRequest) -> Future
+        """
+        Gets and starts the next pending job execution for a thing.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-startnextpendingjobexecution
+
+        Parameters:
+        request - `StartNextPendingJobExecutionRequest` instance.
+
+        Returns a `Future` which will contain a result of `StartNextPendingJobExecutionResponse`
+        if the operation succeeds, or an exception if the operation fails.
+        """
+        return self._start_rpc(
+            pub_op=self._jobs_client.publish_start_next_pending_job_execution,
+            pub_request=request,
+            sub_accepted_op=self._jobs_client.subscribe_to_start_next_pending_job_execution_accepted,
+            sub_rejected_op=self._jobs_client.subscribe_to_start_next_pending_job_execution_rejected,
+            sub_request=iotjobs.StartNextPendingJobExecutionSubscriptionRequest(
+                thing_name=request.thing_name
+            ),
+        )
+
+    def update_job_execution(self, request):
+        # type(iotjobs.UpdateJobExecutionRequest) -> Future
+        """
+        Updates the status of a job execution.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-updatejobexecution
+
+        Parameters:
+        request - `UpdateJobExecutionRequest` instance.
+
+        Returns a `Future` which will contain a result of `UpdateJobExecutionResponse`
+        if the operation succeeds, or an exception if the operation fails.
+        """
+        return self._start_rpc(
+            pub_op=self._jobs_client.publish_update_job_execution,
+            pub_request=request,
+            sub_accepted_op=self._jobs_client.subscribe_to_update_job_execution_accepted,
+            sub_rejected_op=self._jobs_client.subscribe_to_update_job_execution_rejected,
+            sub_request=iotjobs.UpdateJobExecutionSubscriptionRequest(
+                job_id=request.job_id, thing_name=request.thing_name
+            ),
+        )
+
+    def subscribe_to_job_executions_changed_events(self, request, on_event):
+        # type: (JobExecutionsChangedSubscriptionRequest, typing.Callable[[JobExecutionsChangedEvent], None]) -> typing.Tuple[concurrent.futures.Future, str]
+        """
+        Subscribe to receive events whenever a job execution is added to or
+        removed from the list of pending job executions for a thing.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-jobexecutionschanged
+
+        Parameters:
+        request - `JobExecutionsChangedSubscriptionRequest` instance.
+        on_event - Callback to invoke each time the on_event event is received.
+                The callback should take 1 argument of type `JobExecutionsChangedEvent`.
+                The callback is not expected to return anything.
+
+        Returns two values immediately. The first is a `Future`
+        which will contain a result of `None` when the server has acknowledged
+        the subscription, or an exception if the subscription fails. The second
+        value is a topic which may be passed to `unsubscribe()` to stop
+        receiving messages. Note that messages may arrive before the
+        subscription is acknowledged.
+        """
+        return self._jobs_client.subscribe_to_job_executions_changed_events(
+            request, on_event
+        )
+
+    def subscribe_to_next_job_execution_changed_events(self, request, on_event):
+        # type: (NextJobExecutionChangedSubscriptionRequest, typing.Callable[[NextJobExecutionChangedEvent], None]) -> typing.Tuple[concurrent.futures.Future, str]
+        """
+        Subscribe to receive events whenever there is a change to which job
+        execution is next on the list of pending job executions for a thing.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-nextjobexecutionchanged
+
+        Parameters:
+        request - `NextJobExecutionChangedSubscriptionRequest` instance.
+        on_event - Callback to invoke each time the on_event event is received.
+                The callback should take 1 argument of type `NextJobExecutionChangedEvent`.
+                The callback is not expected to return anything.
+
+        Returns two values immediately. The first is a `concurrent.futures.Future`
+        which will contain a result of `None` when the server has acknowledged
+        the subscription, or an exception if the subscription fails. The second
+        value is a topic which may be passed to `unsubscribe()` to stop
+        receiving messages. Note that messages may arrive before the
+        subscription is acknowledged.
+        """
+        return self._jobs_client.subscribe_to_next_job_execution_changed_events(
+            request, on_event
+        )
+
+    def _transform_result(self, result):
+        if isinstance(result, iotjobs.RejectedError):
+            return JobsErrorResponse(result)
+        else:
+            return result
+
+
+class ShadowErrorResponse(Exception):
+    """Exception for when the server responds with a rejection of the request."""
+    def __init__(self, response):
+        self.response = response  # type: iotshadow.ErrorResponse
+
+
+class IotShadowRpcClient(_MqttRpcServiceClient):
+    """
+    This alternative to the `IoTShadowClient` handles the complexity of
+    performing RPCs (remote procedure calls) over the MQTT's
+    publish/subscribe architecture.
+    """
+
+    def __init__(self, mqtt_connection):
+        # type: (mqtt.Connection) -> None
+        super(IotShadowRpcClient, self).__init__(
+            iotshadow.IotShadowClient(mqtt_connection)
+        )
+        self._shadow_client = self._mqtt_service_client  # type: iotshadow.IotShadowClient
+
+    def delete_shadow(self, request):
+        # type(iotshadow.DeleteShadowRequest) -> Future
+        """
+        Delete the shadow.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#delete-rejected-pub-sub-topic
+
+        Parameters:
+        request - `DeleteShadowRequest` instance.
+
+        Returns a `Future` which will contain a result of `DeleteShadowResponse`
+        if the operation succeeds, or an exception if the operation fails.
+        """
+        return self._start_rpc(
+            pub_op=self._shadow_client.publish_delete_shadow,
+            pub_request=request,
+            sub_accepted_op=self._shadow_client.subscribe_to_delete_shadow_accepted,
+            sub_rejected_op=self._shadow_client.subscribe_to_delete_shadow_rejected,
+            sub_request=iotshadow.DeleteShadowSubscriptionRequest(
+                thing_name=request.thing_name
+            ),
+        )
+
+    def get_shadow(self, request):
+        # type: (iotshadow.GetShadowRequest) -> Future
+        """
+        Get the shadow.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#get-pub-sub-topic
+
+        Parameters:
+        request - `GetShadowRequest` instance.
+
+        Returns a `Future` which will contain a result of `GetShadowResponse`
+        if the operation succeeds, or an exception if the operation fails.
+        """
+        return self._start_rpc(
+            pub_op=self._shadow_client.publish_get_shadow,
+            pub_request=request,
+            sub_accepted_op=self._shadow_client.subscribe_to_get_shadow_accepted,
+            sub_rejected_op=self._shadow_client.subscribe_to_get_shadow_rejected,
+            sub_request=iotshadow.GetShadowSubscriptionRequest(
+                thing_name=request.thing_name
+            ),
+        )
+
+    def update_shadow(self, request):
+        # type(iotshadow.UpdateShadowRequest) -> Future
+        """
+        Update the shadow.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#update-pub-sub-topic
+
+        Parameters:
+        request - `UpdateShadowRequest` instance.
+
+        Returns a `Future` which will contain a result of `UpdateShadowResponse`
+        if the operation succeeds, or an exception if the operation fails.
+        """
+        return self._start_rpc(
+            pub_op=self._shadow_client.publish_update_shadow,
+            pub_request=request,
+            sub_accepted_op=self._shadow_client.subscribe_to_update_shadow_accepted,
+            sub_rejected_op=self._shadow_client.subscribe_to_update_shadow_rejected,
+            sub_request=iotshadow.UpdateShadowSubscriptionRequest(
+                thing_name=request.thing_name
+            ),
+        )
+
+    def subscribe_to_shadow_delta_updated_events(self, request, on_event):
+        # type: (iotshadow.ShadowDeltaUpdatedSubscriptionRequest, typing.Callable[[ShadowDeltaUpdatedEvent], None]) -> typing.Tuple[concurrent.futures.Future, str]
+        """
+        Subscribe to receive events whenever the shadow is updated and
+        contains different values for desired and reported states.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#update-delta-pub-sub-topic
+
+        Parameters:
+        request - `ShadowDeltaUpdatedSubscriptionRequest` instance.
+        on_event - Callback to invoke each time the on_event event is received.
+                The callback should take 1 argument of type `ShadowDeltaUpdatedEvent`.
+                The callback is not expected to return anything.
+
+        Returns two values immediately. The first is a `Future`
+        which will contain a result of `None` when the server has acknowledged
+        the subscription, or an exception if the subscription fails. The second
+        value is a topic which may be passed to `unsubscribe()` to stop
+        receiving messages. Note that messages may arrive before the
+        subscription is acknowledged.
+        """
+        return self._shadow_client.subscribe_to_shadow_delta_updated_events(
+            request, on_event
+        )
+
+    def subscribe_to_shadow_updated_events(self, request, on_event):
+        # type: (ShadowUpdatedSubscriptionRequest, typing.Callable[[ShadowUpdatedEvent], None]) -> typing.Tuple[concurrent.futures.Future, str]
+        """
+        Subscribe to receive events whenever the shadow is updated.
+
+        API Docs: https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-mqtt.html#update-documents-pub-sub-topic
+
+        Parameters:
+        request - `ShadowUpdatedSubscriptionRequest` instance.
+        on_event - Callback to invoke each time the on_event event is received.
+                The callback should take 1 argument of type `ShadowUpdatedEvent`.
+                The callback is not expected to return anything.
+
+        Returns two values immediately. The first is a `Future`
+        which will contain a result of `None` when the server has acknowledged
+        the subscription, or an exception if the subscription fails. The second
+        value is a topic which may be passed to `unsubscribe()` to stop
+        receiving messages. Note that messages may arrive before the
+        subscription is acknowledged.
+        """
+        return self._shadow_client.subscribe_to_shadow_updated_events(request, on_event)
+
+    def _transform_result(self, result):
+        if isinstance(result, iotshadow.ErrorResponse):
+            return ShadowErrorResponse(result)
+        else:
+            return result

--- a/samples/shadow_rpc.py
+++ b/samples/shadow_rpc.py
@@ -1,0 +1,295 @@
+# Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import print_function
+import argparse
+from aws_crt import io, mqtt
+from awsiot import iotshadow, rpc
+from concurrent import futures
+import sys
+import threading
+import traceback
+
+# - Overview -
+# This sample uses the AWS IoT Device Shadow Service to keep a property in
+# sync between device and server. Imagine a light whose color may be changed
+# through an app, or set by a local user.
+#
+# - Instructions -
+# Once connected, type a value in the terminal and press Enter to update
+# the property's "reported" value. The sample also responds when the "desired"
+# value changes on the server. To observe this, edit the Shadow document in
+# the AWS Console and set a new "desired" value.
+#
+# - Detail -
+# On startup, the sample requests the shadow document to learn the property's
+# initial state. The sample also subscribes to "delta" events from the server,
+# which are sent when a property's "desired" value differs from its "reported"
+# value. When the sample learns of a new desired value, that value is changed
+# on the device and an update is sent to the server with the new "reported"
+# value.
+
+parser = argparse.ArgumentParser(description="Device Shadow sample keeps a property in sync across client and server")
+parser.add_argument('--endpoint', required=True, help="Your AWS IoT custom endpoint, not including a port. " +
+                                                      "Ex: \"w6zbse3vjd5b4p-ats.iot.us-west-2.amazonaws.com\"")
+parser.add_argument('--cert', required=True, help="File path to your client certificate, in PEM format")
+parser.add_argument('--key', required=True, help="File path to your private key file, in PEM format")
+parser.add_argument('--root-ca', help="File path to root certificate authority, in PEM format. " +
+                                      "Necessary if MQTT server uses a certificate that's not already in " +
+                                      "your trust store")
+parser.add_argument('--client-id', default='samples-client-id', help="Client ID for MQTT connection.")
+parser.add_argument('--thing-name', required=True, help="The name assigned to your IoT Thing")
+parser.add_argument('--shadow-property', default="color", help="Name of property in shadow to keep in sync")
+
+# Using globals to simplify sample code
+connected_future = futures.Future()
+is_sample_done = threading.Event()
+
+mqtt_connection = None
+shadow_rpc_client = None
+thing_name = ""
+shadow_property = ""
+
+SHADOW_VALUE_DEFAULT = "off"
+
+class LockedData(object):
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.shadow_value = None
+        self.disconnect_called = False
+
+locked_data = LockedData()
+
+# Function for gracefully quitting this sample
+def exit(msg_or_exception):
+    if isinstance(msg_or_exception, Exception):
+        print("Exiting sample due to exception.")
+        traceback.print_exception(msg_or_exception.__class__, msg_or_exception, sys.exc_info()[2])
+    else:
+        print("Exiting sample:", msg_or_exception)
+
+    with locked_data.lock:
+        if not locked_data.disconnect_called:
+            print("Disconnecting...")
+            locked_data.disconnect_called = True
+            mqtt_connection.disconnect()
+
+def on_connected(return_code, session_present):
+    # type: (int, bool) -> None
+    print("Connect completed with code: {}".format(return_code))
+    if return_code == 0:
+        connected_future.set_result(None)
+    else:
+        connected_future.set_exception(RuntimeError("Connection failed with code: {}".format(return_code)))
+
+def on_disconnected(return_code):
+    # type: (int) -> bool
+    print("Disconnected with code: {}".format(return_code))
+    with locked_data.lock:
+        if locked_data.disconnect_called:
+            # Signal that sample is finished
+            is_sample_done.set()
+            # Don't attempt to reconnect
+            return False
+        else:
+            # Attempt to reconnect
+            return True
+
+def on_get_shadow_completed(future):
+    try:
+        print("Finished getting initial shadow state.")
+        response = future.result() # type: (iotshadow.GetShadowResponse)
+        with locked_data.lock:
+            if locked_data.shadow_value is not None:
+                print("  Ignoring initial query because a delta event has already been received.")
+                return
+
+        if response.state:
+            if response.state.delta:
+                value = response.state.delta.get(shadow_property)
+                if value:
+                    print("  Shadow contains delta value '{}'.".format(value))
+                    change_shadow_value(value)
+                    return
+
+            if response.state.reported:
+                value = response.state.reported.get(shadow_property)
+                if value:
+                    print("  Shadow contains reported value '{}'.".format(value))
+                    set_local_value_due_to_initial_query(response.state.reported[shadow_property])
+                    return
+
+        print("  Shadow document lacks '{}' property. Setting defaults...".format(shadow_property))
+        change_shadow_value(SHADOW_VALUE_DEFAULT)
+        return
+
+    except rpc.ShadowErrorResponse as e:
+        if e.response.code == 404:
+            print("  Thing has no shadow document. Creating with defaults...")
+            change_shadow_value(SHADOW_VALUE_DEFAULT)
+        else:
+            exit(e)
+
+    except Exception as e:
+        exit(e)
+
+def on_shadow_delta_updated(delta):
+    # type: (iotshadow.ShadowDeltaUpdatedEvent) -> None
+    try:
+        print("Received shadow delta event.")
+        if delta.state and (shadow_property in delta.state):
+            value = delta.state[shadow_property]
+            if value is None:
+                print("  Delta reports that '{}' was deleted. Resetting defaults...".format(shadow_property))
+                change_shadow_value(SHADOW_VALUE_DEFAULT)
+                return
+            else:
+                print("  Delta reports that desired value is '{}'. Changing local value...".format(value))
+                change_shadow_value(value)
+        else:
+            print("  Delta did not report a change in '{}'".format(shadow_property))
+
+    except Exception as e:
+        exit(e)
+
+def on_update_shadow_completed(future):
+    try:
+        print("Update complete.")
+        response = future.result()  # type: (iotshadow.UpdateShadowResponse)
+        print("  reported shadow value is '{}'.".format(response.state.reported[shadow_property]))
+        print("Enter desired value: ") # remind user they can input new values
+
+    except Exception as e:
+        exit(e)
+
+def set_local_value_due_to_initial_query(reported_value):
+    with locked_data.lock:
+        locked_data.shadow_value = reported_value
+    print("Enter desired value: ") # remind user they can input new values
+
+def change_shadow_value(value):
+    with locked_data.lock:
+        if locked_data.shadow_value == value:
+            print("Local value is already '{}'.".format(value))
+            print("Enter desired value: ") # remind user they can input new values
+            return
+
+        print("Changed local shadow value to '{}'.".format(value))
+        locked_data.shadow_value = value
+
+    print("Updating reported shadow value to '{}'...".format(value))
+    request = iotshadow.UpdateShadowRequest(
+        thing_name=thing_name,
+        state=iotshadow.ShadowState(
+            reported={ shadow_property: value },
+            desired={ shadow_property: value },
+        )
+    )
+    future = shadow_rpc_client.update_shadow(request)
+    future.add_done_callback(on_update_shadow_completed)
+
+def user_input_thread_fn():
+    while True:
+        try:
+            # Read user input
+            try:
+                new_value = raw_input() # python 2 only
+            except NameError:
+                new_value = input() # python 3 only
+
+            # If user wants to quit sample, then quit.
+            # Otherwise change the shadow value.
+            if new_value in ['exit', 'quit']:
+                exit("User has quit")
+                break
+            else:
+                change_shadow_value(new_value)
+
+        except Exception as e:
+            print("Exception on input thread.")
+            exit(e)
+            break
+
+def launch_user_input_thread(future):
+    if future.exception():
+        return
+
+    user_input_thread = threading.Thread(target=user_input_thread_fn, name='user_input_thread')
+    user_input_thread.daemon = True
+    user_input_thread.start()
+
+
+if __name__ == '__main__':
+    # Process input args
+    args = parser.parse_args()
+    thing_name = args.thing_name
+    shadow_property = args.shadow_property
+
+    # Spin up resources
+    event_loop_group = io.EventLoopGroup(1)
+    client_bootstrap = io.ClientBootstrap(event_loop_group)
+
+    tls_options = io.TlsContextOptions.create_client_with_mtls(args.cert, args.key)
+    if args.root_ca:
+        tls_options.override_default_trust_store(ca_path=None, ca_file=args.root_ca)
+    tls_context = io.ClientTlsContext(tls_options)
+
+    mqtt_client = mqtt.Client(client_bootstrap, tls_context)
+
+    port = 443 if io.is_alpn_available() else 8883
+    print("Connecting to {} on port {}...".format(args.endpoint, port))
+    mqtt_connection = mqtt.Connection(
+            client=mqtt_client,
+            client_id=args.client_id)
+    mqtt_connection.connect(
+            host_name = args.endpoint,
+            port = port,
+            on_connect=on_connected,
+            on_disconnect=on_disconnected,
+            use_websocket=False,
+            alpn=None,
+            clean_session=True,
+            keep_alive=6000)
+
+    shadow_rpc_client = rpc.IotShadowRpcClient(mqtt_connection)
+
+    # Wait for connection to be fully established.
+    # Note that it's not necessary to wait, commands issued to the
+    # mqtt_connection before its fully connected will simply be queued.
+    # But this sample waits here so it's obvious when a connection
+    # fails or succeeds.
+    connected_future.result()
+
+    try:
+        print("Subscribing to Delta events...")
+        delta_subscribed_future, _ = shadow_rpc_client.subscribe_to_shadow_delta_updated_events(
+            request=iotshadow.ShadowDeltaUpdatedSubscriptionRequest(args.thing_name),
+            on_event=on_shadow_delta_updated)
+
+
+        print("Requesting current shadow state...")
+        get_shadow_future = shadow_rpc_client.get_shadow(
+            iotshadow.GetShadowRequest(thing_name=args.thing_name)
+        )
+
+        get_shadow_future.add_done_callback(on_get_shadow_completed)
+
+        # When the initial query finishes, launch a thread to read user input.
+        get_shadow_future.add_done_callback(launch_user_input_thread)
+
+    except Exception as e:
+        exit(e)
+
+    # Wait for the sample to finish (user types 'quit', or an error occurs)
+    is_sample_done.wait()


### PR DESCRIPTION
It's a ton of code, but only the RPC base class really requires close attention.

Base Class for handling RPCs in the existing IoT Service APIs. This handles the laborious and error-prone process of performing an RPC:
- Subscribe for 2 topics (unless another RPC already subscribed for them)
- Ensure both subscriptions succeeded
- Publish request
- Ensure publish succeeded
- When response is received, pair it with the corresponding request by client token.

Also subclasses for Jobs and Shadow services. The only controversial move on these is that I also copy/pasted over the pure-subscribe operations. With the idea that this is an **alternative** service client, rather than an additional helper class for wrangling the RPC operations, but you should still use the original service class for pure-subscribe operations. By making it an alternate class, it's simpler for the user, and also they're less likely to muck things up by accidentally subscribing to a topic that the RPC handler wanted to use.

Also includes a copy/paste/modify of the shadow sample, using RPCs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
