### PR TITLE
Awscrt 0.5.6

### DIFF
--- a/continuous-delivery/publish_to_test_pypi.yml
+++ b/continuous-delivery/publish_to_test_pypi.yml
@@ -13,7 +13,7 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - cd aws-iot-device-sdk-python-v2 
+      - cd aws-iot-device-sdk-python-v2
       - python3 setup.py sdist bdist_wheel --universal
       - python3 -m twine upload -r testpypi dist/*
   post_build:

--- a/continuous-delivery/test_prod_pypi.yml
+++ b/continuous-delivery/test_prod_pypi.yml
@@ -17,8 +17,9 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - cd aws-iot-device-sdk-python-v2 
+      - cd aws-iot-device-sdk-python-v2
       - CURRENT_TAG_VERSION=$(git describe --tags | cut -f2 -dv)
+      - python3 continuous-delivery/wait-for-pypi.py awsiotsdk $CURRENT_TAG_VERSION --index https://pypi.python.org/pypi
       - python3 -m pip install --user awsiotsdk==$CURRENT_TAG_VERSION
       - python3 samples/basic_discovery.py --region us-east-1 --cert /tmp/certificate.pem --key /tmp/privatekey.pem --root-ca /tmp/AmazonRootCA1.pem --thing-name aws-sdk-crt-unit-test --print-discover-resp-only -v Trace
 

--- a/continuous-delivery/test_test_pypi.yml
+++ b/continuous-delivery/test_test_pypi.yml
@@ -17,10 +17,11 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - cd aws-iot-device-sdk-python-v2 
+      - cd aws-iot-device-sdk-python-v2
       - CURRENT_TAG_VERSION=$(git describe --tags | cut -f2 -dv)
       # this is here because typing isn't in testpypi, so pull it from prod instead
       - python3 -m pip install typing
+      - python3 continuous-delivery/wait-for-pypi.py awsiotsdk $CURRENT_TAG_VERSION --index https://test.pypi.org/pypi
       - python3 -m pip install -i https://testpypi.python.org/simple --user awsiotsdk==$CURRENT_TAG_VERSION
       - python3 samples/basic_discovery.py --region us-east-1 --cert /tmp/certificate.pem --key /tmp/privatekey.pem --root-ca /tmp/AmazonRootCA1.pem --thing-name aws-sdk-crt-unit-test --print-discover-resp-only -v Trace
 

--- a/continuous-delivery/wait-for-pypi.py
+++ b/continuous-delivery/wait-for-pypi.py
@@ -1,0 +1,42 @@
+import argparse
+import subprocess
+import sys
+import time
+
+DEFAULT_TIMEOUT = 60 * 30 # 30 min
+DEFAULT_INTERVAL = 5
+DEFAULT_INDEX_URL = 'https://pypi.python.org/pypi'
+
+
+def wait(package, version, index_url=DEFAULT_INDEX_URL, timeout=DEFAULT_TIMEOUT, interval=DEFAULT_INTERVAL):
+    give_up_time = time.time() + timeout
+    while True:
+        output = subprocess.check_output([sys.executable, '-m', 'pip', 'search', '--index', index_url, package])
+        output = output.decode()
+
+        # output looks like: 'awscrt (0.3.1)  - A common runtime for AWS Python projects\n...'
+        if output.startswith('{} ({})'.format(package, version)):
+            return True
+
+        if time.time() >= give_up_time:
+            return False
+
+        time.sleep(interval)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('package', help="Packet name")
+    parser.add_argument('version', help="Package version")
+    parser.add_argument('--index', default=DEFAULT_INDEX_URL, metavar='<url>',
+                        help="Base URL of Python Package Index. (default {})".format(DEFAULT_INDEX_URL))
+    parser.add_argument('--timeout', type=float, default=DEFAULT_TIMEOUT, metavar='<sec>',
+                        help="Give up after N seconds.")
+    parser.add_argument('--interval', type=float, default=DEFAULT_INTERVAL, metavar='<sec>',
+                        help="Query PyPI every N seconds")
+    args = parser.parse_args()
+
+    if wait(args.package, args.version, args.index, args.timeout, args.interval):
+        print('{} {} is available in pypi'.format(args.package, args.version))
+    else:
+        exit("Timed out waiting for pypi to report {} {} as latest".format(args.package, args.version))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     url='https://github.com/aws/aws-iot-device-sdk-python-v2',
     packages = ['awsiot'],
     install_requires=[
-        'awscrt==0.5.5',
+        'awscrt==0.5.6',
         'futures;python_version<"3.2"',
         'typing;python_version<"3.5"',
     ],


### PR DESCRIPTION
Also incorporate `wait-for-pypi.py` into continuous-delivery pipeline, which is copy/pasted from awscrt.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
