### PR TITLE
Update awscrt to 0.5.11

### DIFF
--- a/continuous-delivery/test_version_exists
+++ b/continuous-delivery/test_version_exists
@@ -13,7 +13,13 @@ if [ "$CURRENT_TAG" != "$CURRENT_TAG_VERSION" ]; then
     exit 1
 fi
 
-if pip install -vvv awsiotsdk==$CURRENT_TAG_VERSION; then
+SETUP_PY_VERSION=$(python setup.py --version)
+if [ "$CURRENT_TAG_VERSION" != "$SETUP_PY_VERSION" ]; then
+    echo "Current tag version does not match version in setup.py: $CURRENT_TAG_VERSION != $SETUP_PY_VERSION"
+    exit 1
+fi
+
+if pip install --no-cache-dir -vvv awsiotsdk==$CURRENT_TAG_VERSION; then
     echo "$CURRENT_TAG_VERSION is already in pypi, cut a new tag if you want to upload another version."
     exit 1
 fi

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ from setuptools import setup
 
 setup(
     name='awsiotsdk',
-    version='1.0.3',
+    version='1.0.4',
     description='AWS IoT SDK based on the AWS Common Runtime',
     author='AWS SDK Common Runtime Team',
     url='https://github.com/aws/aws-iot-device-sdk-python-v2',
     packages = ['awsiot'],
     install_requires=[
-        'awscrt==0.5.6',
+        'awscrt==0.5.11',
         'futures;python_version<"3.2"',
         'typing;python_version<"3.5"',
     ],


### PR DESCRIPTION
Update `awscrt` to version 0.5.11. Improvements include:
- MQTT improvements
  - Fix `on_connection_resumed` callback's `return_code` argument.
  - Reduce default duration between MQTT keep-alive pings.
  - Drop connection if server CONNACK takes too long.
- Fix crash-on-exit which was common on Windows.
- GCC 8 support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
