### PR TITLE
Fix deployment script that broke in new docker image

### DIFF
--- a/continuous-delivery/test_version_exists
+++ b/continuous-delivery/test_version_exists
@@ -13,13 +13,13 @@ if [ "$CURRENT_TAG" != "$CURRENT_TAG_VERSION" ]; then
     exit 1
 fi
 
-SETUP_PY_VERSION=$(python setup.py --version)
+SETUP_PY_VERSION=$(python3 setup.py --version)
 if [ "$CURRENT_TAG_VERSION" != "$SETUP_PY_VERSION" ]; then
     echo "Current tag version does not match version in setup.py: $CURRENT_TAG_VERSION != $SETUP_PY_VERSION"
     exit 1
 fi
 
-if pip install --no-cache-dir -vvv awsiotsdk==$CURRENT_TAG_VERSION; then
+if python3 -m pip install --no-cache-dir -vvv awsiotsdk==$CURRENT_TAG_VERSION; then
     echo "$CURRENT_TAG_VERSION is already in pypi, cut a new tag if you want to upload another version."
     exit 1
 fi


### PR DESCRIPTION
This stage never explicitly had python2, it only worked because the old docker images happened to have python2. Broken when we upgrade images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
