### PR TITLE
add install step for Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ pip install awsiotsdk
 pip install ./aws-iot-device-sdk-python-v2
 ```
 
+## Install for Raspberry Pi ([buster](https://www.raspberrypi.org/downloads/raspbian/))
+
+```
+sudo apt-get update
+sudo apt-get install cmake
+sudo apt-get install libssl-dev
+sudo pip install awscrt
+sudo pip install awsiotsdk
+```
+
 # Samples
 
 ## pubsub

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ pip install awsiotsdk
 pip install ./aws-iot-device-sdk-python-v2
 ```
 
-## Install for Raspberry Pi ([buster](https://www.raspberrypi.org/downloads/raspbian/))
+## Installation Issues
+
+`awsiotsdk` depends on [awscrt](https://github.com/awslabs/aws-crt-python), which makes use of C extensions. Precompiled wheels are downloaded when installing on major platforms (Mac, Windows, Linux, Raspbian (python3 only)). If wheels are unavailable for your platform (ex: Raspbian with python2.7), your machine must compile some C libraries. If you encounter issues, install the following and try again:
 
 ```
 sudo apt-get update
 sudo apt-get install cmake
 sudo apt-get install libssl-dev
-sudo pip install awscrt
-sudo pip install awsiotsdk
 ```
 
 # Samples


### PR DESCRIPTION
*Issue #, if available:*

Raspberry Pi occurs an error at installing awsiotsdk

*Description of changes:*

This changes show the step to install AWS IoT Device SDK Python on Raspberry Pi (buster)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
