### PR TITLE
added a github action to close stale issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41B Bug report"
 about: Create a report to help us improve
 title: ''
-labels: bug report, needs-triage
+labels: bug, needs-triage
 assignees: ''
 
 ---

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -30,7 +30,7 @@ jobs:
         closed-for-staleness-label: closed-for-staleness
 
         # Issue timing
-        days-before-stale: 7
+        days-before-stale: 15
         days-before-close: 3
         days-before-ancient: 365
 

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -1,0 +1,46 @@
+name: "Close stale issues"
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: "/15 * * * *"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v2
+      with:
+        # Setting messages to an empty string will cause the automation to skip
+        # that category
+        ancient-issue-message: Greetings! Sorry to say but this is a very old issue that is probably not getting as much attention as it deservers. We encourage you to check if this is still an issue in the latest release and if you find that this is still a problem, please feel free to open a new one.
+        stale-issue-message: Greetings! It looks like this issue hasn’t been active in longer than a week. We encourage you to check if this is still an issue in the latest release. Because it has been longer than a week since the last update on this, and in the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment or add an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
+        stale-pr-message: Greetings! It looks like this PR hasn’t been active in longer than a week, add a comment or an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
+
+        # These labels are required
+        stale-issue-label: closing-soon
+        exempt-issue-label: investigating
+        stale-pr-label: closing-soon
+        exempt-pr-label: pr/needs-review
+        response-requested-label: response-requested
+
+        # Don't set closed-for-staleness label to skip closing very old issues
+        # regardless of label
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-stale: 7
+        days-before-close: 3
+        days-before-ancient: 365
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 1
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        # dry-run: true

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -3,7 +3,7 @@ name: "Close stale issues"
 # Controls when the action will run.
 on:
   schedule:
-    - cron: "/15 * * * *"
+    - cron: "/30 * * * *"
 
 jobs:
   cleanup:


### PR DESCRIPTION
*Issue #, if available:*
NA
*Description of changes:*
Added a new github action it will:
- check for ancient issues (more than a year with no update) : it will message and mark for closing soon.
- check for stale issues (more than a week with no update) : same but different message prompting for update.
- check for closing soon label and close issues that have not been updated for 3 days after labeled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
