### PR TITLE
Fix documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,12 +289,12 @@ Source: `samples/fleetprovisioning.py`
 
 Run the sample using createKeysAndCertificate:
 ```
-python fleetprovisioning.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --thing-name <name> --templateName <name> --templateParameters <parameters>
+python fleetprovisioning.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --templateName <name> --templateParameters <parameters>
 ```
 
 Run the sample using createCertificateFromCsr:
 ```
-python fleetprovisioning.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --thing-name <name> --templateName <name> --templateParameters <parameters> --csr <csr file>
+python fleetprovisioning.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --templateName <name> --templateParameters <parameters> --csr <csr file>
 ```
 
 Your Thing's


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-iot-device-sdk-python-v2/issues/71

*Description of changes:* Remove the thing name argument from documentation of fleetprovisioning sample


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
