### PR TITLE
All V2 SDK samples can share policies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ and receive.
         "iot:Receive"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/samples/test"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/test/topic"
       ]
     },
     {
@@ -90,7 +90,7 @@ and receive.
         "iot:Subscribe"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/samples/test"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/test/topic"
       ]
     },
     {
@@ -99,7 +99,7 @@ and receive.
         "iot:Connect"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
       ]
     }
   ]
@@ -184,7 +184,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
@@ -269,7 +269,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
@@ -316,7 +316,7 @@ and receive.
       "Resource": [
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create/json",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json"
       ]
     },
     {
@@ -329,11 +329,10 @@ and receive.
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create/json/rejected",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json/accepted",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json/rejected",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json/accepted",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json/rejected"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json/accepted",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json/rejected"
       ]
     },
-    
     {
       "Effect": "Allow",
       "Action": [
@@ -344,14 +343,14 @@ and receive.
         "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/certificates/create/json/rejected",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/certificates/create-from-csr/json/accepted",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/certificates/create-from-csr/json/rejected",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/provisioning-templates/<b>templatename<b>/provision/json/accepted",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/provisioning-templates/<b>templatename<b>/provision/json/rejected"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/provisioning-templates/<b>templatename</b>/provision/json/accepted",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/provisioning-templates/<b>templatename</b>/provision/json/rejected"
       ]
     },
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -35,7 +35,7 @@ and receive.
         "iot:Receive"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/samples/test"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/test/topic"
       ]
     },
     {
@@ -44,7 +44,7 @@ and receive.
         "iot:Subscribe"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/samples/test"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/test/topic"
       ]
     },
     {
@@ -53,7 +53,7 @@ and receive.
         "iot:Connect"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
       ]
     }
   ]
@@ -138,7 +138,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
@@ -223,7 +223,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
@@ -291,7 +291,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -19,7 +19,7 @@ parser.add_argument('-r', '--root-ca', action='store', dest='root_ca_path', help
 parser.add_argument('-c', '--cert', action='store', required=True, dest='certificate_path', help='Certificate file path')
 parser.add_argument('-k', '--key', action='store', required=True, dest='private_key_path', help='Private key file path')
 parser.add_argument('-n', '--thing-name', action='store', required=True, dest='thing_name', help='Targeted thing name')
-parser.add_argument('-t', '--topic', action='store', dest='topic', default='sdk/test/Python', help='Targeted topic')
+parser.add_argument('-t', '--topic', action='store', dest='topic', default='test/topic', help='Targeted topic')
 parser.add_argument('-m', '--mode', action='store', dest='mode', default='both',
                     help='Operation modes: %s'%str(allowed_actions))
 parser.add_argument('-M', '--message', action='store', dest='message', default='Hello World!',

--- a/samples/fleetprovisioning.py
+++ b/samples/fleetprovisioning.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 import traceback
+from uuid import uuid4
 import json
 
 # - Overview -
@@ -35,7 +36,7 @@ parser.add_argument('--key', help="File path to your private key file, in PEM fo
 parser.add_argument('--root-ca', help="File path to root certificate authority, in PEM format. " +
                                       "Necessary if MQTT server uses a certificate that's not already in " +
                                       "your trust store")
-parser.add_argument('--client-id', default='samples-client-id', help="Client ID for MQTT connection.")
+parser.add_argument('--client-id', default="test-" + str(uuid4()), help="Client ID for MQTT connection.")
 parser.add_argument('--use-websocket', default=False, action='store_true',
                     help="To use a websocket instead of raw mqtt. If you " +
                          "specify this option you must specify a region for signing, you can also enable proxy mode.")

--- a/samples/jobs.py
+++ b/samples/jobs.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 import traceback
+from uuid import uuid4
 
 # - Overview -
 # This sample uses the AWS IoT Jobs Service to receive and execute operations
@@ -42,7 +43,7 @@ parser.add_argument('--key', help="File path to your private key file, in PEM fo
 parser.add_argument('--root-ca', help="File path to root certificate authority, in PEM format. " +
                                       "Necessary if MQTT server uses a certificate that's not already in " +
                                       "your trust store")
-parser.add_argument('--client-id', default='samples-client-id', help="Client ID for MQTT connection.")
+parser.add_argument('--client-id', default="test-" + str(uuid4()), help="Client ID for MQTT connection.")
 parser.add_argument('--thing-name', required=True, help="The name assigned to your IoT Thing")
 parser.add_argument('--job-time', default=5, type=float, help="Emulate working on job by sleeping this many seconds.")
 parser.add_argument('--use-websocket', default=False, action='store_true',

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -9,6 +9,7 @@ from awsiot import mqtt_connection_builder
 import sys
 import threading
 import time
+from uuid import uuid4
 
 # This sample uses the Message Broker for AWS IoT to send and receive messages
 # through an MQTT connection. On startup, the device connects to the server,
@@ -24,8 +25,8 @@ parser.add_argument('--key', help="File path to your private key, in PEM format.
 parser.add_argument('--root-ca', help="File path to root certificate authority, in PEM format. " +
                                       "Necessary if MQTT server uses a certificate that's not already in " +
                                       "your trust store.")
-parser.add_argument('--client-id', default='samples-client-id', help="Client ID for MQTT connection.")
-parser.add_argument('--topic', default="samples/test", help="Topic to subscribe to, and publish messages to.")
+parser.add_argument('--client-id', default="test-" + str(uuid4()), help="Client ID for MQTT connection.")
+parser.add_argument('--topic', default="test/topic", help="Topic to subscribe to, and publish messages to.")
 parser.add_argument('--message', default="Hello World!", help="Message to publish. " +
                                                               "Specify empty string to publish nothing.")
 parser.add_argument('--count', default=10, type=int, help="Number of messages to publish/receive before exiting. " +

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -11,6 +11,7 @@ from concurrent.futures import Future
 import sys
 import threading
 import traceback
+from uuid import uuid4
 
 # - Overview -
 # This sample uses the AWS IoT Device Shadow Service to keep a property in
@@ -39,7 +40,7 @@ parser.add_argument('--key', help="File path to your private key file, in PEM fo
 parser.add_argument('--root-ca', help="File path to root certificate authority, in PEM format. " +
                                       "Necessary if MQTT server uses a certificate that's not already in " +
                                       "your trust store")
-parser.add_argument('--client-id', default='samples-client-id', help="Client ID for MQTT connection.")
+parser.add_argument('--client-id', default="test-" + str(uuid4()), help="Client ID for MQTT connection.")
 parser.add_argument('--thing-name', required=True, help="The name assigned to your IoT Thing")
 parser.add_argument('--shadow-property', default="color", help="Name of property in shadow to keep in sync")
 parser.add_argument('--use-websocket', default=False, action='store_true',


### PR DESCRIPTION
ISSUE:
Currently, the "Getting Started Kit" vended by the IoT console vends a policy that doesn't match the strings used by any V2 SDK samples. So they fail right off the bat 😢

SOLUTION:
Let's get all the V2 SDKs using the same strings, then we can create a policy to fit them all. I'd like to put wildcards in the new policy so users can toy around a little bit, but include the word "test" everywhere so they feel inclined to change it before they ship.

Also, let's get all the samples putting randomness into the client-id, since colliding IDs are a frequent source of confusion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
