### PR TITLE
update awscrt to 0.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/aws/aws-iot-device-sdk-python-v2',
     packages = ['awsiot'],
     install_requires=[
-        'awscrt==0.6.2',
+        'awscrt==0.8.0',
         'futures;python_version<"3.2"',
         'typing;python_version<"3.5"',
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
from 0.6.2 to 0.8.0

includes:
- API CHANGE: awscrt.auth.AwsSigningConfig.signed_body_value is now a string instead of an enum.
- API CHANGE: Added check for iOS platform
- BUGFIX: websocket no longer hangs if CLOSE frame cannot be sent.
- BUGFIX: Fixes a crash when shutting down an mqtt connection with an incomplete request with no callback from aws-c-mqtt


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
