### PR TITLE
Improve README titles and add TOC to samples README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS IoT SDK for Python v2
+# AWS IoT Device SDK for Python v2
 This document provides information about the AWS IoT device SDK for Python V2.
 
 If you have any issues or feature requests, please file an issue or pull request.

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,4 +1,9 @@
-# Samples
+# Sample apps for the AWS IoT Device SDK for Python v2
+
+* [pubsub](#pubsub)
+* [shadow](#shadow)
+* [fleet provisioning](#fleet-provisioning)
+* [basic discovery](#basic-discovery)
 
 ## pubsub
 This sample uses the
@@ -306,7 +311,7 @@ get the sample up and running.  These steps assume you have the AWS CLI installe
 sufficient permission to perform all of the listed operations.  These steps are based on provisioning setup steps
 that can be found at [Embedded C SDK Setup](https://docs.aws.amazon.com/freertos/latest/lib-ref/c-sdk/provisioning/provisioning_tests.html#provisioning_system_tests_setup)
 
-First, create the IAM role that will be needed by the fleet provisioning template. Replace `RoleName` with a name of the role you want to create. 
+First, create the IAM role that will be needed by the fleet provisioning template. Replace `RoleName` with a name of the role you want to create.
 <pre>
 aws iam create-role \
     --role-name [RoleName] \
@@ -318,17 +323,17 @@ aws iam attach-role-policy \
         --role-name [RoleName] \
         --policy-arn arn:aws:iam::aws:policy/service-role/AWSIoTThingsRegistration
 </pre>
-Finally, create the template resource which will be used for provisioning by the demo application. This needs to be done only 
-once.  To create a template, the following AWS CLI command may be used. Replace `TemplateName` with the name of the fleet 
-provisioning template you want to create. Replace `RoleName` with the name of the role you created previously. Replace 
-`TemplateJSON` with the template body as a JSON string (containing escape characters). Replace `account` with your AWS 
-account number. 
+Finally, create the template resource which will be used for provisioning by the demo application. This needs to be done only
+once.  To create a template, the following AWS CLI command may be used. Replace `TemplateName` with the name of the fleet
+provisioning template you want to create. Replace `RoleName` with the name of the role you created previously. Replace
+`TemplateJSON` with the template body as a JSON string (containing escape characters). Replace `account` with your AWS
+account number.
 <pre>
 aws iot create-provisioning-template \
         --template-name [TemplateName] \
         --provisioning-role-arn arn:aws:iam::[account]:service-role/[RoleName] \
         --template-body "[TemplateJSON]" \
-        --enabled 
+        --enabled
 </pre>
 The rest of the instructions assume you have used the following for the template body:
 <pre>
@@ -337,13 +342,13 @@ The rest of the instructions assume you have used the following for the template
 If you use a different body, you may need to pass in different template parameters.
 ##### Running the sample and provisioning using a certificate-key set from a provisioning claim
 
-To run the provisioning sample, you'll need a certificate and key set with sufficient permissions.  Provisioning certificates are normally 
+To run the provisioning sample, you'll need a certificate and key set with sufficient permissions.  Provisioning certificates are normally
 created ahead of time and placed on your device, but for this sample, we will just create them on the fly.  You can also
 use any certificate set you've already created if it has sufficient IoT permissions and in doing so, you can skip the step
 that calls `create-provisioning-claim`.
- 
+
 We've included a script in the utils folder that creates certificate and key files from the response of calling
-`create-provisioning-claim`. These dynamically sourced certificates are only valid for five minutes.  When running the command, 
+`create-provisioning-claim`. These dynamically sourced certificates are only valid for five minutes.  When running the command,
 you'll need to substitute the name of the template you previously created, and on Windows, replace the paths with something appropriate.
 
 (Optional) Create a temporary provisioning claim certificate set:
@@ -352,7 +357,7 @@ aws iot create-provisioning-claim --template-name [TemplateName] | python ../uti
 </pre>
 
 The provisioning claim's cert and key set have been written to `/tmp/provision*`.  Now you can use these temporary keys
-to perform the actual provisioning.  If you are not using the temporary provisioning certificate, replace the paths for `--cert` 
+to perform the actual provisioning.  If you are not using the temporary provisioning certificate, replace the paths for `--cert`
 and `--key` appropriately:
 
 <pre>
@@ -384,7 +389,7 @@ aws iot create-provisioning-claim --template-name [TemplateName] | python ../uti
 Finally, supply the certificate signing request while invoking the provisioning sample.  As with the previous workflow, if
 using a permanent certificate set, replace the paths specified in the `--cert` and `--key` arguments:
 <pre>
-python fleetprovisioning.py --endpoint [your endpoint]-ats.iot.[region].amazonaws.com --root-ca [pathToRootCA] --cert /tmp/provision.cert.pem --key /tmp/provision.private.key --templateName [TemplateName]--templateParameters "{\"SerialNumber\":\"1\",\"DeviceLocation\":\"Seattle\"}" --csr /tmp/deviceCert.csr 
+python fleetprovisioning.py --endpoint [your endpoint]-ats.iot.[region].amazonaws.com --root-ca [pathToRootCA] --cert /tmp/provision.cert.pem --key /tmp/provision.private.key --templateName [TemplateName]--templateParameters "{\"SerialNumber\":\"1\",\"DeviceLocation\":\"Seattle\"}" --csr /tmp/deviceCert.csr
 </pre>
 
 ## basic discovery


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:* Minor text-only edits to provide a smoother transition from the AWS IoT Core Developer Guide to the SDK documentation. (e.g. the links in https://docs.aws.amazon.com/iot/latest/developerguide/iot-connect-devices.html#iot-connect-device-sdks that land on an SDK README page.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
