### PR TITLE
Remove support for python 2

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,3 @@
-AWS IoT SDK for Python v2
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+AWS IoT Device SDK v2 for Python
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# AWS IoT Device SDK for Python v2
-This document provides information about the AWS IoT device SDK for Python V2.
+# AWS IoT Device SDK v2 for Python
+This document provides information about the AWS IoT Device SDK v2 for Python.
 
 If you have any issues or feature requests, please file an issue or pull request.
 
@@ -35,25 +35,24 @@ to Python by the `awscrt` package ([PyPI](https://pypi.org/project/awscrt/)) ([G
 
 ### Install from PyPI
 ```
-pip install awsiotsdk
+python3 -m pip install awsiotsdk
 ```
 
 ### Install from source
 ```
-pip install ./aws-iot-device-sdk-python-v2
+git clone https://github.com/aws/aws-iot-device-sdk-python-v2.git
+python3 -m pip install ./aws-iot-device-sdk-python-v2
 ```
 
 ### Installation Issues
 
-`awsiotsdk` depends on [awscrt](https://github.com/awslabs/aws-crt-python), which makes use of C extensions. Precompiled wheels are downloaded when installing on major platforms (Mac, Windows, Linux, Raspbian (python3 only)). If wheels are unavailable for your platform (ex: Raspbian with python2.7), your machine must compile some C libraries. If you encounter issues, install the following and try again:
+`awsiotsdk` depends on [awscrt](https://github.com/awslabs/aws-crt-python), which makes use of C extensions. Precompiled wheels are downloaded when installing on major platforms (Mac, Windows, Linux, Raspbian. If wheels are unavailable for your platform, your machine must compile some C libraries. If you encounter issues, install the following and try again:
 
 ```
 sudo apt-get update
 sudo apt-get install cmake
 sudo apt-get install libssl-dev
 ```
-
-
 
 ## Mac-Only TLS Behavior
 

--- a/awsiot/__init__.py
+++ b/awsiot/__init__.py
@@ -19,7 +19,7 @@ T = TypeVar('T')
 PayloadObj = Dict[str, Any]
 PayloadToClassFn = Callable[[PayloadObj], T]
 
-class MqttServiceClient(object):
+class MqttServiceClient:
     """
     Base class for an AWS MQTT Service Client
     """
@@ -153,7 +153,7 @@ class MqttServiceClient(object):
 
         return future, topic
 
-class ModeledClass(object):
+class ModeledClass:
     """
     Base for input/output classes generated from an AWS service model.
     """

--- a/awsiot/greengrass_discovery.py
+++ b/awsiot/greengrass_discovery.py
@@ -7,7 +7,7 @@ import awsiot
 from concurrent.futures import Future
 import json
 
-class DiscoveryClient(object):
+class DiscoveryClient:
     __slots__ = ['_bootstrap', '_tls_context', '_socket_options', '_region', '_tls_connection_options', '_gg_server_name', 'gg_url', 'port']
 
     def __init__(self, bootstrap, socket_options, tls_context, region):
@@ -63,7 +63,7 @@ class DiscoveryClient(object):
                 http_stream = connection.request(
                     request=request,
                     on_body=on_incoming_body)
-               
+
                 http_stream.activate()
                 http_stream.completion_future.add_done_callback(on_request_complete)
 

--- a/builder.json
+++ b/builder.json
@@ -23,6 +23,11 @@
         },
         "manylinux": {
             "post_build_steps": [
+                ["echo", "------ Python 3.7 ------"],
+                ["/opt/python/cp37-cp37m/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
+                ["/opt/python/cp37-cp37m/bin/python", "-m", "pip", "install", ".", "--verbose"],
+                ["/opt/python/cp37-cp37m/bin/python", "-m", "pip", "install", "boto3", "autopep8"],
+                ["/opt/python/cp37-cp37m/bin/python", "-m", "unittest", "discover", "--verbose"],
                 ["echo", "------ Python 3.6 ------"],
                 ["/opt/python/cp36-cp36m/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
                 ["/opt/python/cp36-cp36m/bin/python", "-m", "pip", "install", ".", "--verbose"],
@@ -32,22 +37,7 @@
                 ["/opt/python/cp35-cp35m/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
                 ["/opt/python/cp35-cp35m/bin/python", "-m", "pip", "install", ".", "--verbose"],
                 ["/opt/python/cp35-cp35m/bin/python", "-m", "pip", "install", "boto3", "autopep8"],
-                ["/opt/python/cp35-cp35m/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["echo", "------ Python 3.4 ------"],
-                ["/opt/python/cp34-cp34m/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
-                ["/opt/python/cp34-cp34m/bin/python", "-m", "pip", "install", ".", "--verbose"],
-                ["/opt/python/cp34-cp34m/bin/python", "-m", "pip", "install", "boto3", "autopep8"],
-                ["/opt/python/cp34-cp34m/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["echo", "------ Python 2.7 narrow-unicode ------"],
-                ["/opt/python/cp27-cp27m/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
-                ["/opt/python/cp27-cp27m/bin/python", "-m", "pip", "install", ".", "--verbose"],
-                ["/opt/python/cp27-cp27m/bin/python", "-m", "pip", "install", "boto3", "autopep8"],
-                ["/opt/python/cp27-cp27m/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["echo", "------ Python 2.7 wide-unicode ------"],
-                ["/opt/python/cp27-cp27mu/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
-                ["/opt/python/cp27-cp27mu/bin/python", "-m", "pip", "install", ".", "--verbose"],
-                ["/opt/python/cp27-cp27mu/bin/python", "-m", "pip", "install", "boto3", "autopep8"],
-                ["/opt/python/cp27-cp27mu/bin/python", "-m", "unittest", "discover", "--verbose"]
+                ["/opt/python/cp35-cp35m/bin/python", "-m", "unittest", "discover", "--verbose"]
             ],
             "run_tests": false,
             "_comment": "manylinux has all its own build steps, turn off 'tests' which is where normal build steps are declared. using data to program sucks"

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'AWS IoT Device SDK Python v2'
+project = 'AWS IoT Device SDK v2 for Python'
 copyright = '%s, Amazon Web Services, Inc' % datetime.now().year
 author = 'Amazon Web Services, Inc'
 

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -1,10 +1,10 @@
-.. AWS IoT Device SDK Python v2 documentation master file, created by
+.. AWS IoT Device SDK v2 for Python documentation master file, created by
    sphinx-quickstart on Mon Aug 17 14:57:36 2020.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-AWS IoT Device SDK Python v2
-============================
+AWS IoT Device SDK v2 for Python
+================================
 
 Python bindings for the AWS IoT Device API.
 
@@ -18,7 +18,7 @@ API Reference
 -------------
 .. toctree::
    :maxdepth: 2
-   
+
    awsiot/greengrass_discovery
    awsiot/iotidentity
    awsiot/iotjobs

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,4 +1,4 @@
-# Sample apps for the AWS IoT Device SDK for Python v2
+# Sample apps for the AWS IoT Device SDK v2 for Python
 
 * [pubsub](#pubsub)
 * [shadow](#shadow)
@@ -19,7 +19,7 @@ Source: `samples/pubsub.py`
 
 Run the sample like this:
 ```
-python pubsub.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file>
+python3 pubsub.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file>
 ```
 
 Your Thing's
@@ -90,7 +90,7 @@ Source: `samples/shadow.py`
 
 Run the sample like this:
 ```
-python shadow.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --thing-name <name>
+python3 shadow.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --thing-name <name>
 ```
 
 Your Thing's
@@ -176,7 +176,7 @@ Source: `samples/jobs.py`
 
 Run the sample like this:
 ```
-python jobs.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --thing-name <name>
+python3 jobs.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --thing-name <name>
 ```
 
 Your Thing's
@@ -248,12 +248,12 @@ Source: `samples/fleetprovisioning.py`
 
 Run the sample using createKeysAndCertificate:
 ```
-python fleetprovisioning.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --templateName <name> --templateParameters <parameters>
+python3 fleetprovisioning.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --templateName <name> --templateParameters <parameters>
 ```
 
 Run the sample using createCertificateFromCsr:
 ```
-python fleetprovisioning.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --templateName <name> --templateParameters <parameters> --csr <csr file>
+python3 fleetprovisioning.py --endpoint <endpoint> --root-ca <file> --cert <file> --key <file> --templateName <name> --templateParameters <parameters> --csr <csr file>
 ```
 
 Your Thing's
@@ -353,7 +353,7 @@ you'll need to substitute the name of the template you previously created, and o
 
 (Optional) Create a temporary provisioning claim certificate set:
 <pre>
-aws iot create-provisioning-claim --template-name [TemplateName] | python ../utils/parse_cert_set_result.py --path /tmp --filename provision
+aws iot create-provisioning-claim --template-name [TemplateName] | python3 ../utils/parse_cert_set_result.py --path /tmp --filename provision
 </pre>
 
 The provisioning claim's cert and key set have been written to `/tmp/provision*`.  Now you can use these temporary keys
@@ -361,7 +361,7 @@ to perform the actual provisioning.  If you are not using the temporary provisio
 and `--key` appropriately:
 
 <pre>
-python fleetprovisioning.py --endpoint [your endpoint]-ats.iot.[region].amazonaws.com --root-ca [pathToRootCA] --cert /tmp/provision.cert.pem --key /tmp/provision.private.key --templateName [TemplateName]--templateParameters "{\"SerialNumber\":\"1\",\"DeviceLocation\":\"Seattle\"}"
+python3 fleetprovisioning.py --endpoint [your endpoint]-ats.iot.[region].amazonaws.com --root-ca [pathToRootCA] --cert /tmp/provision.cert.pem --key /tmp/provision.private.key --templateName [TemplateName]--templateParameters "{\"SerialNumber\":\"1\",\"DeviceLocation\":\"Seattle\"}"
 </pre>
 
 Notice that we provided substitution values for the two parameters in the template body, `DeviceLocation` and `SerialNumber`.
@@ -383,13 +383,13 @@ openssl req -new -key /tmp/deviceCert.key -out /tmp/deviceCert.csr
 be skipped if you're using a certificate set capable of provisioning the device:
 
 <pre>
-aws iot create-provisioning-claim --template-name [TemplateName] | python ../utils/parse_cert_set_result.py --path /tmp --filename provision
+aws iot create-provisioning-claim --template-name [TemplateName] | python3 ../utils/parse_cert_set_result.py --path /tmp --filename provision
 </pre>
 
 Finally, supply the certificate signing request while invoking the provisioning sample.  As with the previous workflow, if
 using a permanent certificate set, replace the paths specified in the `--cert` and `--key` arguments:
 <pre>
-python fleetprovisioning.py --endpoint [your endpoint]-ats.iot.[region].amazonaws.com --root-ca [pathToRootCA] --cert /tmp/provision.cert.pem --key /tmp/provision.private.key --templateName [TemplateName]--templateParameters "{\"SerialNumber\":\"1\",\"DeviceLocation\":\"Seattle\"}" --csr /tmp/deviceCert.csr
+python3 fleetprovisioning.py --endpoint [your endpoint]-ats.iot.[region].amazonaws.com --root-ca [pathToRootCA] --cert /tmp/provision.cert.pem --key /tmp/provision.private.key --templateName [TemplateName]--templateParameters "{\"SerialNumber\":\"1\",\"DeviceLocation\":\"Seattle\"}" --csr /tmp/deviceCert.csr
 </pre>
 
 ## basic discovery

--- a/samples/fleetprovisioning.py
+++ b/samples/fleetprovisioning.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
-from __future__ import print_function
 import argparse
 from awscrt import auth, http, io, mqtt
 from awsiot import iotidentity
@@ -63,7 +61,7 @@ createKeysAndCertificateResponse = None
 createCertificateFromCsrResponse = None
 registerThingResponse = None
 
-class LockedData(object):
+class LockedData:
     def __init__(self):
         self.lock = threading.Lock()
         self.disconnect_called = False

--- a/samples/jobs.py
+++ b/samples/jobs.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
-from __future__ import print_function
 import argparse
 from awscrt import auth, http, io, mqtt
 from awsiot import iotjobs
@@ -64,7 +62,7 @@ mqtt_connection = None
 jobs_client = None
 thing_name = ""
 
-class LockedData(object):
+class LockedData:
     def __init__(self):
         self.lock = threading.Lock()
         self.disconnect_called = False

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
-from __future__ import print_function
 import argparse
 from awscrt import io, mqtt, auth, http
 from awsiot import mqtt_connection_builder

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from __future__ import absolute_import
-from __future__ import print_function
 import argparse
 from awscrt import auth, io, mqtt, http
 from awsiot import iotshadow
@@ -64,7 +62,7 @@ shadow_property = ""
 
 SHADOW_VALUE_DEFAULT = "off"
 
-class LockedData(object):
+class LockedData:
     def __init__(self):
         self.lock = threading.Lock()
         self.shadow_value = None
@@ -207,10 +205,7 @@ def user_input_thread_fn():
     while True:
         try:
             # Read user input
-            try:
-                new_value = raw_input() # python 2 only
-            except NameError:
-                new_value = input() # python 3 only
+            new_value = input()
 
             # If user wants to quit sample, then quit.
             # Otherwise change the shadow value.

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,9 @@ setup(
     description='AWS IoT SDK based on the AWS Common Runtime',
     author='AWS SDK Common Runtime Team',
     url='https://github.com/aws/aws-iot-device-sdk-python-v2',
-    packages = ['awsiot'],
+    packages=['awsiot'],
     install_requires=[
-        'awscrt==0.8.0',
-        'futures;python_version<"3.2"',
-        'typing;python_version<"3.5"',
+        'awscrt==0.9.0',
     ],
-    python_requires='>=2.7',
+    python_requires='>=3.5',
 )

--- a/test/test_samples.py
+++ b/test/test_samples.py
@@ -1,6 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
-from __future__ import absolute_import, print_function
 import awsiot
 import boto3
 import botocore.exceptions
@@ -43,10 +42,7 @@ class Config:
 
         # boto3 caches the HTTPS connection for the API calls, which appears to the unit test
         # framework as a leak, so ignore it, that's not what we're testing here
-        try:
-            warnings.simplefilter('ignore', ResourceWarning)
-        except NameError:  # Python 2 has no ResourceWarning
-            pass
+        warnings.simplefilter('ignore', ResourceWarning)
 
         try:
             secrets = boto3.client('secretsmanager')

--- a/utils/parse_cert_set_result.py
+++ b/utils/parse_cert_set_result.py
@@ -10,7 +10,7 @@ into usable pem files that you can make IoT connections with.
 
 Example usage:
 
-aws iot create-provisioning-claim --template-name <TemplateName> | python parse_cert_set_result.py --path <PathToOutputtedCerts> --filename <Filename>
+aws iot create-provisioning-claim --template-name <TemplateName> | python3 parse_cert_set_result.py --path <PathToOutputtedCerts> --filename <Filename>
 
 """
 


### PR DESCRIPTION
Python 2's end-of-life date was Jan 1 2020.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
