### PR TITLE
Stop marking wheels as "universal".

### DIFF
--- a/continuous-delivery/publish_to_prod_pypi.yml
+++ b/continuous-delivery/publish_to_prod_pypi.yml
@@ -16,8 +16,8 @@ phases:
       - sed --in-place -E "s/version='.+'/version='${PKG_VERSION}'/" setup.py
   build:
     commands:
-      - echo Build started on `date` 
-      - python3 setup.py sdist bdist_wheel --universal
+      - echo Build started on `date`
+      - python3 setup.py sdist bdist_wheel
       - python3 -m twine upload -r pypi dist/*
   post_build:
     commands:

--- a/continuous-delivery/publish_to_test_pypi.yml
+++ b/continuous-delivery/publish_to_test_pypi.yml
@@ -16,8 +16,8 @@ phases:
       - sed --in-place -E "s/version='.+'/version='${PKG_VERSION}'/" setup.py
   build:
     commands:
-      - echo Build started on `date`      
-      - python3 setup.py sdist bdist_wheel --universal
+      - echo Build started on `date`
+      - python3 setup.py sdist bdist_wheel
       - python3 -m twine upload -r testpypi dist/*
   post_build:
     commands:


### PR DESCRIPTION
We no longer support Python 2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
