### PR TITLE
Fix the wrong link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you still can’t find a solution to your problem open an [issue](https://git
 
 We need your help in making this SDK great. Please participate in the community and contribute to this effort by submitting issues, participating in discussion forums and submitting pull requests through the following channels.
 
-*   [Contributions Guidelines](master/CONTRIBUTING.md)
+*   [Contributions Guidelines](CONTRIBUTING.md)
 *   Articulate your feature request or upvote existing ones on our [Issues](https://github.com/aws/aws-iot-device-sdk-python-v2/issues?q=is%3Aissue+is%3Aopen+label%3Afeature-request) page.
 *   Submit [Issues](https://github.com/aws/aws-iot-device-sdk-python-v2/issues)
 


### PR DESCRIPTION
*Issue #120*

*Description of changes:*
The location of the file is at the same level of the readme.md so remove the "master" directory name in the link.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
