### PR TITLE
Add proper license attribute per OSI license

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -4,7 +4,7 @@
 * [shadow](#shadow)
 * [fleet provisioning](#fleet-provisioning)
 * [basic discovery](#basic-discovery)
-* [IPC with AWS IoT Greengrass to publish to AWS IoT Core](#ipc-greengrass)
+* [IPC with AWS IoT Greengrass to publish to AWS IoT Core](#ipc-with-aws-iot-greengrass-to-publish-to-aws-iot-core)
 
 ## pubsub
 This sample uses the

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 setup(
     name='awsiotsdk',
     version='1.0.0-dev',
-    license='Apache Software License',
+    license='License :: OSI Approved :: Apache Software License',
     description='AWS IoT SDK based on the AWS Common Runtime',
     author='AWS SDK Common Runtime Team',
     url='https://github.com/aws/aws-iot-device-sdk-python-v2',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import setup, find_packages
 setup(
     name='awsiotsdk',
     version='1.0.0-dev',
+    license='Apache-2.0',
     description='AWS IoT SDK based on the AWS Common Runtime',
     author='AWS SDK Common Runtime Team',
     url='https://github.com/aws/aws-iot-device-sdk-python-v2',

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,16 @@ from setuptools import setup, find_packages
 setup(
     name='awsiotsdk',
     version='1.0.0-dev',
-    license='Apache-2.0',
+    license='Apache Software License',
     description='AWS IoT SDK based on the AWS Common Runtime',
     author='AWS SDK Common Runtime Team',
     url='https://github.com/aws/aws-iot-device-sdk-python-v2',
     packages=find_packages(include=['awsiot*']),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
     install_requires=[
         'awscrt==0.9.15',
     ],


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
We should be using the OSI license attribute in the classifier, and the license attribute should match that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
