### PR TITLE
embed awsiotsdk version in metrics string, instead of awscrt

### DIFF
--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -115,7 +115,7 @@ def _get_metrics_str():
         try:
             import pkg_resources
             try:
-                version = pkg_resources.get_distribution("awscrt").version
+                version = pkg_resources.get_distribution("awsiotsdk").version
                 _metrics_str = "?SDK=PythonV2&Version={}".format(version)
             except pkg_resources.DistributionNotFound:
                 _metrics_str = "?SDK=PythonV2&Version=dev"


### PR DESCRIPTION
mqtt_connection_builder.py used to live inside awscrt, so that's what it queried. But now this code lives inside the SDK, and that's the version we really care about.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
