### PR TITLE
Adding `--port` option to pubsub.py client

### DIFF
--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -141,16 +141,18 @@ def _builder(
         tls_ctx_options.override_default_trust_store_from_path(ca_dirpath, ca_filepath)
 
     if use_websockets:
-        port = 443
+        default_port = 443
         if awscrt.io.is_alpn_available():
             tls_ctx_options.alpn_list = ['http/1.1']
     else:
         port = 8883
         if awscrt.io.is_alpn_available():
-            port = 443
+            default_port = 443
             tls_ctx_options.alpn_list = ['x-amzn-mqtt-ca']
 
-    port = kwargs.get('port', port)
+    port = kwargs.get('port', default_port)
+    if not isinstance(port, int): 
+        port = default_port
 
     socket_options = awscrt.io.SocketOptions()
     socket_options.connect_timeout_ms = kwargs.get('tcp_connect_timeout_ms', 5000)

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -110,31 +110,18 @@ if __name__ == '__main__':
             keep_alive_secs=6)
 
     else:
-        if args.port:
-            mqtt_connection = mqtt_connection_builder.mtls_from_path(
-                endpoint=args.endpoint,
-                port=args.port,
-                cert_filepath=args.cert,
-                pri_key_filepath=args.key,
-                client_bootstrap=client_bootstrap,
-                ca_filepath=args.root_ca,
-                on_connection_interrupted=on_connection_interrupted,
-                on_connection_resumed=on_connection_resumed,
-                client_id=args.client_id,
-                clean_session=False,
-                keep_alive_secs=6)
-        else:
-            mqtt_connection = mqtt_connection_builder.mtls_from_path(
-                endpoint=args.endpoint,
-                cert_filepath=args.cert,
-                pri_key_filepath=args.key,
-                client_bootstrap=client_bootstrap,
-                ca_filepath=args.root_ca,
-                on_connection_interrupted=on_connection_interrupted,
-                on_connection_resumed=on_connection_resumed,
-                client_id=args.client_id,
-                clean_session=False,
-                keep_alive_secs=6)
+        mqtt_connection = mqtt_connection_builder.mtls_from_path(
+            endpoint=args.endpoint,
+            port=args.port,
+            cert_filepath=args.cert,
+            pri_key_filepath=args.key,
+            client_bootstrap=client_bootstrap,
+            ca_filepath=args.root_ca,
+            on_connection_interrupted=on_connection_interrupted,
+            on_connection_resumed=on_connection_resumed,
+            client_id=args.client_id,
+            clean_session=False,
+            keep_alive_secs=6)
 
     print("Connecting to {} with client ID '{}'...".format(
         args.endpoint, args.client_id))

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 parser = argparse.ArgumentParser(description="Send and receive messages through and MQTT connection.")
 parser.add_argument('--endpoint', required=True, help="Your AWS IoT custom endpoint, not including a port. " +
                                                       "Ex: \"abcd123456wxyz-ats.iot.us-east-1.amazonaws.com\"")
+parser.add_argument('--port', help="The port to connect to when using MQTT/TLS. AWS IoT supports 443 and 8883", type=int)
 parser.add_argument('--cert', help="File path to your client certificate, in PEM format.")
 parser.add_argument('--key', help="File path to your private key, in PEM format.")
 parser.add_argument('--root-ca', help="File path to root certificate authority, in PEM format. " +
@@ -109,17 +110,32 @@ if __name__ == '__main__':
             keep_alive_secs=6)
 
     else:
-        mqtt_connection = mqtt_connection_builder.mtls_from_path(
-            endpoint=args.endpoint,
-            cert_filepath=args.cert,
-            pri_key_filepath=args.key,
-            client_bootstrap=client_bootstrap,
-            ca_filepath=args.root_ca,
-            on_connection_interrupted=on_connection_interrupted,
-            on_connection_resumed=on_connection_resumed,
-            client_id=args.client_id,
-            clean_session=False,
-            keep_alive_secs=6)
+        if args.port:
+            mqtt_connection = mqtt_connection_builder.mtls_from_path(
+                endpoint=args.endpoint,
+                port=args.port,
+                cert_filepath=args.cert,
+                pri_key_filepath=args.key,
+                client_bootstrap=client_bootstrap,
+                ca_filepath=args.root_ca,
+                on_connection_interrupted=on_connection_interrupted,
+                on_connection_resumed=on_connection_resumed,
+                client_id=args.client_id,
+                clean_session=False,
+                keep_alive_secs=6)
+        else:
+            mqtt_connection = mqtt_connection_builder.mtls_from_path(
+                endpoint=args.endpoint,
+                port=args.port,
+                cert_filepath=args.cert,
+                pri_key_filepath=args.key,
+                client_bootstrap=client_bootstrap,
+                ca_filepath=args.root_ca,
+                on_connection_interrupted=on_connection_interrupted,
+                on_connection_resumed=on_connection_resumed,
+                client_id=args.client_id,
+                clean_session=False,
+                keep_alive_secs=6)
 
     print("Connecting to {} with client ID '{}'...".format(
         args.endpoint, args.client_id))

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -126,7 +126,6 @@ if __name__ == '__main__':
         else:
             mqtt_connection = mqtt_connection_builder.mtls_from_path(
                 endpoint=args.endpoint,
-                port=args.port,
                 cert_filepath=args.cert,
                 pri_key_filepath=args.key,
                 client_bootstrap=client_bootstrap,


### PR DESCRIPTION
*Issue #, if available:*
#182 
*Description of changes:*
Added `--port` option to be able to set the port when connecting with MQTT/TLS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
