### PR TITLE
Update to CRT 0.11.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.11.20',
+        'awscrt==0.11.22',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
* On Windows, always perform an SNI check even with an overridden root CA
* On Windows, properly honor the verify_peer = false option
* Fix instability with raspberry PI and input stream seeking by doing a better job of modeling file seek offset type and size.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
