### PR TITLE
Fix CA override functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.11.25',
+        'awscrt==0.12.0',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
Update to awscrt 0.12.0. This fixes the issue where "override_default_trust_store" functions did not actually override the system trust store on Linux and Apple platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
