### PR TITLE
Added feature to connect using AWS IoT custom authorizer

### DIFF
--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -1,42 +1,27 @@
 """
 Builder functions to create a :class:`awscrt.mqtt.Connection`, configured for use with AWS IoT Core.
 The following keyword arguments are common to all builder functions:
-
 Required Keyword Arguments:
-
     **endpoint** (`str`): Host name of AWS IoT server.
-
     **client_bootstrap** (:class:`awscrt.io.ClientBootstrap`): Client bootstrap used to establish connection.
-
     **client_id** (`str`): ID to place in CONNECT packet. Must be unique across all devices/clients.
             If an ID is already in use, the other client will be disconnected.
-
 Optional Keyword Arguments (omit, or set `None` to get default value):
-
     **on_connection_interrupted** (`Callable`): Callback invoked whenever the MQTT connection is lost.
         The MQTT client will automatically attempt to reconnect.
         The function should take the following arguments return nothing:
-
             *   `connection` (:class:`awscrt.mqtt.Connection`): This MQTT Connection.
-
             *   `error` (:class:`awscrt.exceptions.AwsCrtError`): Exception which caused connection loss.
-
             *   `**kwargs` (dict): Forward-compatibility kwargs.
-
     **on_connection_resumed** (`Callable`): Callback invoked whenever the MQTT connection
         is automatically resumed. Function should take the following arguments and return nothing:
-
             *   `connection` (:class:`awscrt.mqtt.Connection`): This MQTT Connection
-
             *   `return_code` (:class:`awscrt.mqtt.ConnectReturnCode`): Connect return
                 code received from the server.
-
             *   `session_present` (bool): True if resuming existing session. False if new session.
                 Note that the server has forgotten all previous subscriptions if this is False.
                 Subscriptions can be re-established via resubscribe_existing_topics().
-
             *   `**kwargs` (dict): Forward-compatibility kwargs.
-
     **clean_session** (`bool`): Whether or not to start a clean session with each reconnect.
         If True, the server will forget all subscriptions with each reconnect.
         Set False to request that the server resume an existing session
@@ -45,52 +30,37 @@ Optional Keyword Arguments (omit, or set `None` to get default value):
         whether an existing session was successfully resumed.
         If an existing session is resumed, the server remembers previous subscriptions
         and sends mesages (with QoS1 or higher) that were published while the client was offline.
-
     **reconnect_min_timeout_secs** (`int`): Minimum time to wait between reconnect attempts.
         Must be <= `reconnect_max_timeout_secs`.
         Wait starts at min and doubles with each attempt until max is reached.
-
     **reconnect_max_timeout_secs** (`int`): Maximum time to wait between reconnect attempts.
         Must be >= `reconnect_min_timeout_secs`.
         Wait starts at min and doubles with each attempt until max is reached.
-
     **keep_alive_secs** (`int`): The keep alive value, in seconds, to send in CONNECT packet.
         A PING will automatically be sent at this interval.
         The server will assume the connection is lost if no PING is received after 1.5X this value.
         Default is 1200sec (20 minutes). This duration must be longer than ping_timeout_ms.
-
     **ping_timeout_ms** (`int`): Milliseconds to wait for ping response before client assumes
         the connection is invalid and attempts to reconnect.
         Default is 3000ms (3 seconds). This duration must be shorter than `keep_alive_secs`.
-
     **protocol_operation_timeout_ms** (`int`): Milliseconds to wait for the response to the operation
         requires response by protocol. Set to zero to disable timeout. Otherwise,
         the operation will fail if no response is received within this amount of time after
         the packet is written to the socket
         It applied to PUBLISH (QoS>0) and UNSUBSCRIBE now.
-
     **will** (:class:`awscrt.mqtt.Will`): Will to send with CONNECT packet. The will is
         published by the server when its connection to the client is unexpectedly lost.
-
     **username** (`str`): Username to connect with.
-
     **password** (`str`): Password to connect with.
-
     **port** (`int`): Override default server port.
         Default port is 443 if system supports ALPN or websockets are being used.
         Otherwise, default port is 8883.
-
     **tcp_connect_timeout_ms** (`int`): Milliseconds to wait for TCP connect response. Default is 5000ms (5 seconds).
-
     **ca_filepath** (`str`): Override default trust store with CA certificates from this PEM formatted file.
-
     **ca_dirpath** (`str`): Override default trust store with CA certificates loaded from this directory (Unix only).
-
     **ca_bytes** (`bytes`): Override default trust store with CA certificates from these PEM formatted bytes.
-
     **enable_metrics_collection** (`bool`): Whether to send the SDK version number in the CONNECT packet.
         Default is True.
-
     **http_proxy_options** (:class: 'awscrt.http.HttpProxyOptions'): HTTP proxy options to use
 """
 
@@ -100,6 +70,7 @@ Optional Keyword Arguments (omit, or set `None` to get default value):
 import awscrt.auth
 import awscrt.io
 import awscrt.mqtt
+from awscrt.io import TlsContextOptions
 
 
 def _check_required_kwargs(**kwargs):
@@ -112,7 +83,6 @@ def _get(kwargs, name, default=None):
     """
     Returns kwargs['name'] if it exists and is not None.
     Otherwise returns default.
-
     This function exists so users can pass some_arg=None to get its default
     value, instead of literally passing None.
     """
@@ -156,15 +126,26 @@ def _builder(
         tls_ctx_options.override_default_trust_store_from_path(ca_dirpath, ca_filepath)
 
     port = _get(kwargs, 'port')
+    password = _get(kwargs, 'password')
+    use_customAuth = True if password is not None else False
     if port is None:
         # prefer 443, even for direct MQTT connections, since it's less likely to be blocked by firewalls
-        if use_websockets or awscrt.io.is_alpn_available():
+        # If a password is specified for a custom authorizd, force port 443
+        if use_websockets or awscrt.io.is_alpn_available() or  use_customAuth :
             port = 443
         else:
             port = 8883
 
     if port == 443 and awscrt.io.is_alpn_available():
-        tls_ctx_options.alpn_list = ['http/1.1'] if use_websockets else ['x-amzn-mqtt-ca']
+        alpn = []
+        if use_websockets:
+            alpn = ['http/1.1']
+        elif use_customAuth:
+            alpn = ['mqtt']
+        else:
+            alpn = ['x-amzn-mqtt-ca']
+
+        tls_ctx_options.alpn_list = alpn
 
     socket_options = awscrt.io.SocketOptions()
     socket_options.connect_timeout_ms = _get(kwargs, 'tcp_connect_timeout_ms', 5000)
@@ -212,18 +193,25 @@ def _builder(
         proxy_options=proxy_options,
     )
 
-
+def tls_custom_auth(**kwargs) -> awscrt.mqtt.Connection:
+    """
+    This builder creates an :class:`awscrt.mqtt.Connection`, configured for an TLS MQTT connection to AWS IoT without
+    using client side certificates and keys for authentication using AWS IoT custom authorizer and MQTT userid,passsword parameter. 
+    This function takes all :mod:`common arguments<awsiot.mqtt_connection_builder>`
+    described at the top of this doc.
+    """
+    _check_required_kwargs(**kwargs)
+    tls_ctx_options = TlsContextOptions()
+    return _builder(tls_ctx_options, **kwargs)
+    
 def mtls_from_path(cert_filepath, pri_key_filepath, **kwargs) -> awscrt.mqtt.Connection:
     """
     This builder creates an :class:`awscrt.mqtt.Connection`, configured for an mTLS MQTT connection to AWS IoT.
     TLS arguments are passed as filepaths.
-
     This function takes all :mod:`common arguments<awsiot.mqtt_connection_builder>`
     described at the top of this doc, as well as...
-
     Keyword Args:
         cert_filepath (str): Path to certificate file.
-
         pri_key_filepath (str): Path to private key file.
     """
     _check_required_kwargs(**kwargs)
@@ -235,13 +223,10 @@ def mtls_from_bytes(cert_bytes, pri_key_bytes, **kwargs) -> awscrt.mqtt.Connecti
     """
     This builder creates an :class:`awscrt.mqtt.Connection`, configured for an mTLS MQTT connection to AWS IoT.
     TLS arguments are passed as in-memory bytes.
-
     This function takes all :mod:`common arguments<awsiot.mqtt_connection_builder>`
     described at the top of this doc, as well as...
-
     Keyword Args:
         cert_bytes (bytes): Certificate file bytes.
-
         pri_key_bytes (bytes): Private key bytes.
     """
     _check_required_kwargs(**kwargs)
@@ -257,19 +242,14 @@ def websockets_with_default_aws_signing(
     """
     This builder creates an :class:`awscrt.mqtt.Connection`, configured for an MQTT connection over websockets to AWS IoT.
     The websocket handshake is signed using credentials from the credentials_provider.
-
     This function takes all :mod:`common arguments<awsiot.mqtt_connection_builder>`
     described at the top of this doc, as well as...
-
     Keyword Args:
         region (str): AWS region to use when signing.
-
         credentials_provider (awscrt.auth.AwsCredentialsProvider): Source of AWS credentials to use when signing.
-
         websocket_proxy_options (awscrt.http.HttpProxyOptions): Deprecated,
             for proxy settings use `http_proxy_options` (described in
             :mod:`common arguments<awsiot.mqtt_connection_builder>`)
-
     """
     _check_required_kwargs(**kwargs)
 
@@ -300,23 +280,18 @@ def websockets_with_custom_handshake(
     """
     This builder creates an :class:`awscrt.mqtt.Connection`, configured for an MQTT connection over websockets,
     with a custom function to transform the websocket handshake request before it is sent to the server.
-
     This function takes all :mod:`common arguments<awsiot.mqtt_connection_builder>`
     described at the top of this doc, as well as...
-
     Keyword Args:
         websocket_handshake_transform (Callable): Function to transform websocket handshake request.
             If provided, function is called each time a websocket connection is attempted.
             The function may modify the HTTP request before it is sent to the server.
             See :class:`awscrt.mqtt.WebsocketHandshakeTransformArgs` for more info.
             Function should take the following arguments and return nothing:
-
                 *   `transform_args` (:class:`awscrt.mqtt.WebsocketHandshakeTransformArgs`):
                     Contains HTTP request to be transformed. Function must call
                     `transform_args.done()` when complete.
-
                 *   `**kwargs` (dict): Forward-compatibility kwargs.
-
         websocket_proxy_options (awscrt.http.HttpProxyOptions):  Deprecated,
             for proxy settings use `http_proxy_options` (described in
             :mod:`common arguments<awsiot.mqtt_connection_builder>`)


### PR DESCRIPTION
*Description of changes:
Made minor changes to the `mqtt_connection_builder.py` to allow connecting to an AWS IoT endpoint with a custom authorizer. I added one helper function `tls_custom_auth` to establish a tls connection without using client side certs/keys. 
I also changed the logic to force port 443  and set ALPN to `mqtt` when a `password` field is specified in the connection parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
