### PR TITLE
Feature/add client token to delta

### DIFF
--- a/awsiot/__init__.py
+++ b/awsiot/__init__.py
@@ -15,7 +15,7 @@ from concurrent.futures import Future
 import json
 from typing import Any, Callable, Dict, Optional, Tuple, TypeVar
 
-__version__ = '1.0.0-dev'
+__version__ = '1.0.1-dev'
 
 T = TypeVar('T')
 

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -1194,8 +1194,6 @@ class ShadowDeltaUpdatedEvent(awsiot.ModeledClass):
     __slots__ = ['metadata', 'state', 'timestamp', 'version', 'client_token']
 
     def __init__(self, *args, **kwargs):
-        print("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ TARTIFLETTETEEE")
-        print(kwargs)
         self.metadata = kwargs.get('metadata')
         self.state = kwargs.get('state')
         self.timestamp = kwargs.get('timestamp')

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -1191,16 +1191,17 @@ class ShadowDeltaUpdatedEvent(awsiot.ModeledClass):
         version (int): The current version of the document for the device's shadow.
     """
 
-    __slots__ = ['metadata', 'state', 'timestamp', 'version']
+    __slots__ = ['metadata', 'state', 'timestamp', 'version', 'client_token']
 
     def __init__(self, *args, **kwargs):
         self.metadata = kwargs.get('metadata')
         self.state = kwargs.get('state')
         self.timestamp = kwargs.get('timestamp')
         self.version = kwargs.get('version')
+        self.client_token = kwargs.get('client_token')
 
         # for backwards compatibility, read any arguments that used to be accepted by position
-        for key, val in zip(['metadata', 'state', 'timestamp', 'version'], args):
+        for key, val in zip(['metadata', 'state', 'timestamp', 'version', 'client_token'], args):
             setattr(self, key, val)
 
     @classmethod
@@ -1219,6 +1220,9 @@ class ShadowDeltaUpdatedEvent(awsiot.ModeledClass):
         val = payload.get('version')
         if val is not None:
             new.version = val
+        val = payload.get('client_token')
+        if val is not None:
+            new.client_token = val
         return new
 
 class ShadowDeltaUpdatedSubscriptionRequest(awsiot.ModeledClass):

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -1194,6 +1194,8 @@ class ShadowDeltaUpdatedEvent(awsiot.ModeledClass):
     __slots__ = ['metadata', 'state', 'timestamp', 'version', 'client_token']
 
     def __init__(self, *args, **kwargs):
+        print("$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ TARTIFLETTETEEE")
+        print(kwargs)
         self.metadata = kwargs.get('metadata')
         self.state = kwargs.get('state')
         self.timestamp = kwargs.get('timestamp')
@@ -1220,7 +1222,7 @@ class ShadowDeltaUpdatedEvent(awsiot.ModeledClass):
         val = payload.get('version')
         if val is not None:
             new.version = val
-        val = payload.get('client_token')
+        val = payload.get('clientToken')
         if val is not None:
             new.client_token = val
         return new


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Adding the client token in a callback for the delta subscription as it is mentionned in the AWS documentation here https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-document.html#device-shadow-example-response-json-delta and not in the SDK. This is valuable information.*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
