### PR TITLE
Support PKCS#11 for mutual TLS on Unix platforms

### DIFF
--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -249,6 +249,61 @@ def mtls_from_bytes(cert_bytes, pri_key_bytes, **kwargs) -> awscrt.mqtt.Connecti
     return _builder(tls_ctx_options, **kwargs)
 
 
+def mtls_with_pkcs11(*,
+                     pkcs11_lib: awscrt.io.Pkcs11Lib,
+                     user_pin: str,
+                     slot_id: int = None,
+                     token_label: str = None,
+                     private_key_label: str = None,
+                     cert_filepath: str = None,
+                     cert_bytes=None,
+                     **kwargs) -> awscrt.mqtt.Connection:
+    """
+    This builder creates an :class:`awscrt.mqtt.Connection`, configured for an mTLS MQTT connection to AWS IoT,
+    using a PKCS#11 library for private key operations.
+
+    This function takes all :mod:`common arguments<awsiot.mqtt_connection_builder>`
+    described at the top of this doc, as well as...
+
+    Keyword Args:
+        pkcs11_lib (awscrt.io.Pkcs11Lib): Use this PKCS#11 library
+
+        user_pin (Optional[str]): User PIN, for logging into the PKCS#11 token.
+            Pass `None` to log into a token with a "protected authentication path".
+
+        slot_id (Optional[int]): ID of slot containing PKCS#11 token.
+            If not specified, the token will be chosen based on other criteria (such as token label).
+
+        token_label (Optional[str]): Label of the PKCS#11 token to use.
+            If not specified, the token will be chosen based on other criteria (such as slot ID).
+
+        private_key_label (Optional[str]): Label of private key object on PKCS#11 token.
+            If not specified, the key will be chosen based on other criteria
+            (such as being the only available private key on the token).
+
+        cert_filepath (Optional[str]): Use this X.509 certificate (file on disk).
+            The certificate must be PEM-formatted. The certificate may be
+            specified by other means instead (ex: `cert_file_contents`)
+
+        cert_bytes (Optional[bytes-like object]):
+            Use this X.509 certificate (contents in memory).
+            The certificate must be PEM-formatted. The certificate may be
+            specified by other means instead (ex: `cert_file_path`)
+    """
+    _check_required_kwargs(**kwargs)
+
+    tls_ctx_options = awscrt.io.TlsContextOptions.create_client_with_mtls_pkcs11(
+        pkcs11_lib=pkcs11_lib,
+        user_pin=user_pin,
+        slot_id=slot_id,
+        token_label=token_label,
+        private_key_label=private_key_label,
+        cert_file_path=cert_filepath,
+        cert_file_contents=cert_bytes)
+
+    return _builder(tls_ctx_options, **kwargs)
+
+
 def websockets_with_default_aws_signing(
         region,
         credentials_provider,

--- a/samples/pkcs11_pubsub.py
+++ b/samples/pkcs11_pubsub.py
@@ -75,9 +75,8 @@ if __name__ == '__main__':
     host_resolver = io.DefaultHostResolver(event_loop_group)
     client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
 
-    print(f"Loading PKCS#11 library: {args.pkcs11_lib} ...")
-    pkcs11_lib = io.Pkcs11Lib(file=args.pkcs11_lib,
-                              behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
+    print(f"Loading PKCS#11 library '{args.pkcs11_lib}' ...")
+    pkcs11_lib = io.Pkcs11Lib(file=args.pkcs11_lib)
     print("Loaded!")
 
     # Create MQTT connection

--- a/samples/pkcs11_pubsub.py
+++ b/samples/pkcs11_pubsub.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 import argparse
-from awscrt import io, mqtt, auth, http
+from awscrt import io, mqtt
 from awsiot import mqtt_connection_builder
 import sys
 import threading
@@ -10,11 +10,14 @@ import time
 from uuid import uuid4
 import json
 
-# This sample uses the Message Broker for AWS IoT to send and receive messages
-# through an MQTT connection. On startup, the device connects to the server,
-# subscribes to a topic, and begins publishing messages to that topic.
-# The device should receive those same messages back from the message broker,
-# since it is subscribed to that same topic.
+# This sample is similar to `samples/pubsub.py` but the private key
+# for mutual TLS is stored on a PKCS#11 compatible smart card or
+# Hardware Security Module (HSM).
+#
+# See `samples/README.md` for instructions on setting up your PKCS#11 device
+# to run this sample.
+#
+# WARNING: Unix only. Currently, TLS integration with PKCS#11 is only available on Unix devices.
 
 parser = argparse.ArgumentParser(description="Send and receive messages through and MQTT connection.")
 parser.add_argument('--endpoint', required=True, help="Your AWS IoT custom endpoint, not including a port. " +

--- a/samples/pkcs11_pubsub.py
+++ b/samples/pkcs11_pubsub.py
@@ -76,7 +76,9 @@ if __name__ == '__main__':
     client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
 
     print(f"Loading PKCS#11 library '{args.pkcs11_lib}' ...")
-    pkcs11_lib = io.Pkcs11Lib(file=args.pkcs11_lib)
+    pkcs11_lib = io.Pkcs11Lib(
+        file=args.pkcs11_lib,
+        behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
     print("Loaded!")
 
     # Create MQTT connection

--- a/samples/pkcs11_pubsub.py
+++ b/samples/pkcs11_pubsub.py
@@ -1,0 +1,167 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+
+import argparse
+from awscrt import io, mqtt, auth, http
+from awsiot import mqtt_connection_builder
+import sys
+import threading
+import time
+from uuid import uuid4
+import json
+
+# This sample uses the Message Broker for AWS IoT to send and receive messages
+# through an MQTT connection. On startup, the device connects to the server,
+# subscribes to a topic, and begins publishing messages to that topic.
+# The device should receive those same messages back from the message broker,
+# since it is subscribed to that same topic.
+
+parser = argparse.ArgumentParser(description="Send and receive messages through and MQTT connection.")
+parser.add_argument('--endpoint', required=True, help="Your AWS IoT custom endpoint, not including a port. " +
+                                                      "Ex: \"abcd123456wxyz-ats.iot.us-east-1.amazonaws.com\"")
+parser.add_argument('--port', type=int, help="Specify port. AWS IoT supports 443 and 8883. (default: auto)")
+parser.add_argument('--cert', required=True, help="File path to your client certificate, in PEM format.")
+parser.add_argument('--root-ca', help="File path to root certificate authority, in PEM format. (default: None)")
+parser.add_argument('--pkcs11-lib', required=True, help="Path to PKCS#11 library.")
+parser.add_argument('--pin', required=True, help="User PIN for logging into PKCS#11 token.")
+parser.add_argument('--token-label', help="Label of PKCS#11 token to use. (default: None) ")
+parser.add_argument('--slot-id', help="Slot ID containing PKCS#11 token to use. (default: None)")
+parser.add_argument('--key-label', help="Label of private key on the PKCS#11 token. (default: None)")
+parser.add_argument('--client-id', default="test-" + str(uuid4()),
+                    help="Client ID for MQTT connection. (default: 'test-*')")
+parser.add_argument('--topic', default="test/topic",
+                    help="Topic to subscribe to, and publish messages to. (default: 'test/topic')")
+parser.add_argument('--message', default="Hello World!",
+                    help="Message to publish. Specify empty string to publish nothing. (default: 'Hello World!')")
+parser.add_argument('--count', default=10, type=int, help="Number of messages to publish/receive before exiting. " +
+                                                          "Specify 0 to run forever. (default: 10)")
+parser.add_argument('--verbosity', choices=[x.name for x in io.LogLevel], default=io.LogLevel.NoLogs.name,
+                    help="Logging level. (default: 'NoLogs')")
+
+# Using globals to simplify sample code
+args = parser.parse_args()
+
+io.init_logging(getattr(io.LogLevel, args.verbosity), 'stderr')
+
+received_count = 0
+received_all_event = threading.Event()
+
+
+def on_connection_interrupted(connection, error, **kwargs):
+    # Callback when connection is accidentally lost.
+    print("Connection interrupted. error: {}".format(error))
+
+
+def on_connection_resumed(connection, return_code, session_present, **kwargs):
+    # Callback when an interrupted connection is re-established.
+    print("Connection resumed. return_code: {} session_present: {}".format(return_code, session_present))
+
+    if return_code == mqtt.ConnectReturnCode.ACCEPTED and not session_present:
+        print("Session did not persist. Resubscribing to existing topics...")
+        resubscribe_future, _ = connection.resubscribe_existing_topics()
+
+        # Cannot synchronously wait for resubscribe result because we're on the connection's event-loop thread,
+        # evaluate result with a callback instead.
+        resubscribe_future.add_done_callback(on_resubscribe_complete)
+
+
+def on_resubscribe_complete(resubscribe_future):
+    resubscribe_results = resubscribe_future.result()
+    print("Resubscribe results: {}".format(resubscribe_results))
+
+    for topic, qos in resubscribe_results['topics']:
+        if qos is None:
+            sys.exit("Server rejected resubscribe to topic: {}".format(topic))
+
+
+# Callback when the subscribed topic receives a message
+def on_message_received(topic, payload, dup, qos, retain, **kwargs):
+    print("Received message from topic '{}': {}".format(topic, payload))
+    global received_count
+    received_count += 1
+    if received_count == args.count:
+        received_all_event.set()
+
+
+if __name__ == '__main__':
+    # Spin up resources
+    event_loop_group = io.EventLoopGroup(1)
+    host_resolver = io.DefaultHostResolver(event_loop_group)
+    client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
+
+    print(f"Loading PKCS#11 library: {args.pkcs11_lib} ...")
+    pkcs11_lib = io.Pkcs11Lib(file=args.pkcs11_lib,
+                              behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
+    print("Loaded!")
+
+    # Create MQTT connection
+    mqtt_connection = mqtt_connection_builder.mtls_with_pkcs11(
+        pkcs11_lib=pkcs11_lib,
+        user_pin=args.pin,
+        slot_id=int(args.slot_id) if args.slot_id else None,
+        token_label=args.token_label,
+        private_key_label=args.key_label,
+        cert_filepath=args.cert,
+        endpoint=args.endpoint,
+        port=args.port,
+        client_bootstrap=client_bootstrap,
+        ca_filepath=args.root_ca,
+        on_connection_interrupted=on_connection_interrupted,
+        on_connection_resumed=on_connection_resumed,
+        client_id=args.client_id,
+        clean_session=False,
+        keep_alive_secs=30,)
+
+    print("Connecting to {} with client ID '{}'...".format(
+        args.endpoint, args.client_id))
+
+    connect_future = mqtt_connection.connect()
+
+    # Future.result() waits until a result is available
+    connect_future.result()
+    print("Connected!")
+
+    # Subscribe
+    print("Subscribing to topic '{}'...".format(args.topic))
+    subscribe_future, packet_id = mqtt_connection.subscribe(
+        topic=args.topic,
+        qos=mqtt.QoS.AT_LEAST_ONCE,
+        callback=on_message_received)
+
+    subscribe_result = subscribe_future.result()
+    print("Subscribed with {}".format(str(subscribe_result['qos'])))
+
+    # Publish message to server desired number of times.
+    # This step is skipped if message is blank.
+    # This step loops forever if count was set to 0.
+    if args.message:
+        if args.count == 0:
+            print("Sending messages until program killed")
+        else:
+            print("Sending {} message(s)".format(args.count))
+
+        publish_count = 1
+        while (publish_count <= args.count) or (args.count == 0):
+            message = "{} [{}]".format(args.message, publish_count)
+            print("Publishing message to topic '{}': {}".format(args.topic, message))
+            message_json = json.dumps(message)
+            mqtt_connection.publish(
+                topic=args.topic,
+                payload=message_json,
+                qos=mqtt.QoS.AT_LEAST_ONCE)
+            time.sleep(1)
+            publish_count += 1
+
+    # Wait for all messages to be received.
+    # This waits forever if count was set to 0.
+    if args.count != 0 and not received_all_event.is_set():
+        print("Waiting for all messages to be received...")
+
+    received_all_event.wait()
+    print("{} message(s) received.".format(received_count))
+
+    # Disconnect
+    print("Disconnecting...")
+    disconnect_future = mqtt_connection.disconnect()
+    disconnect_future.result()
+    print("Disconnected!")

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.12.1',
+        'awscrt==0.13.0',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
- Update to latest `aws-crt-python`, which exposes PKCS#11 functionality (see https://github.com/awslabs/aws-crt-python/pull/323)
- Add `pkcs11_pubsub.py` sample, demonstrating an MQTT connection where the private key is stored in PKCS#11 token.
  - Add docs for sample

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
