### PR TITLE
Added ShadowClearState and adjusted Shadow sample

### DIFF
--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -1277,9 +1277,11 @@ class ShadowMetadata(awsiot.ModeledClass):
         val = payload.get('desired')
         if val is not None:
             new.desired = val
+
         val = payload.get('reported')
         if val is not None:
             new.reported = val
+
         return new
 
 class ShadowState(awsiot.ModeledClass):
@@ -1327,6 +1329,47 @@ class ShadowState(awsiot.ModeledClass):
             payload['desired'] = self.desired
         if self.reported is not None:
             payload['reported'] = self.reported
+        return payload
+
+class ShadowClearState(awsiot.ModeledClass):
+    """
+
+    (Potentially partial) clear state of an AWS IoT thing's shadow.
+
+    Used to clear all of the desired and/or reported state properties of an AWS IoT thing's shadow.
+    All attributes are None by default and may be set by keyword in the constructor.
+
+    Keyword Args:
+        clear_desired (bool): Whether to clear the desired shadow state (defaults to false)
+        clear_reported (bool): Whether to clear the reported shadow state (defaults to false)
+
+    Attributes:
+        clear_desired (bool): Whether to clear the desired shadow state (defaults to false)
+        clear_reported (bool): Whether to clear the reported shadow state (defaults to false)
+    """
+
+    __slots__ = ['clear_desired', 'clear_reported']
+
+    def __init__(self, *args, **kwargs):
+        self.clear_desired = kwargs.get('clear_desired')
+        self.clear_reported = kwargs.get('clear_reported')
+
+    @classmethod
+    def from_payload(cls, payload):
+        # type: (typing.Dict[str, typing.Any]) -> ShadowState
+        new = cls()
+        # nothing to do here - shouldn't occur
+        return new
+
+    def to_payload(self):
+        # type: () -> typing.Dict[str, typing.Any]
+        payload = {} # type: typing.Dict[str, typing.Any]
+        if self.clear_desired is not None:
+            if self.clear_desired == True:
+                payload['desired'] = None
+        if self.clear_reported is not None:
+            if self.clear_reported == True:
+                payload['reported'] = None
         return payload
 
 class ShadowStateWithDelta(awsiot.ModeledClass):


### PR DESCRIPTION
*Issue #, if available:*

Closes #114 

*Description of changes:*

Added a new state called ShadowClearState for clearing the data in an AWS IoT Shadow. This state can be configured to clear all the data in `desired`, `reported`, or both. The Shadow sample was also adjusted to show how to use this new state.

This PR makes the following changes:
* Added ShadowClearState - allows for clearing all the data in a shadow document
  * For example, can be used to clear all the data in the 'desired' shadow property
  * Is configurable and allows for clearing just the desired, just the reported, or both
* Adjusted Shadow sample
  * When you type "none" it will send a None object and clear the property with the same name
  * When you type "clear_shadow" it will send a ShadowClearState and will clear all the data in the 'desired' and 'reported' properties
  * Added condition to check for if the response state is not None, which is what is returned after clearing all the data in a shadow document

_______

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
