### PR TITLE
Rebuilt shadow bindings and updated shadow sample to show how to clear properties

### DIFF
--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -1303,10 +1303,10 @@ class ShadowState(awsiot.ModeledClass):
 
     Attributes:
         desired (typing.Dict[str, typing.Any]): The desired shadow state (from external services and devices).
-        desired_none_is_valid (bool): Set to true to allow desired to be None, clearing the data if sent.
+        desired_none_is_valid (bool): Set to true to allow 'desired' to be None, clearing the data if sent.
 
         reported (typing.Dict[str, typing.Any]): The (last) reported shadow state from the device.
-        reported_none_is_valid (bool): Set to true to allow reported to be None, clearing the data if sent.
+        reported_none_is_valid (bool): Set to true to allow 'reported' to be None, clearing the data if sent.
 
     """
 
@@ -1316,8 +1316,8 @@ class ShadowState(awsiot.ModeledClass):
         self.desired = kwargs.get('desired')
         self.reported = kwargs.get('reported')
 
-        self.desired_none_is_valid = False
-        self.reported_none_is_valid = False
+        self.desired_none_is_valid = kwargs.get('desired', False)
+        self.reported_none_is_valid = kwargs.get('reported', False)
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['desired', 'reported'], args):

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -1316,8 +1316,8 @@ class ShadowState(awsiot.ModeledClass):
         self.desired = kwargs.get('desired')
         self.reported = kwargs.get('reported')
 
-        self.desired_none_is_valid = kwargs.get('desired_none_is_valid')
-        self.reported_none_is_valid = kwargs.get('reported_none_is_valid')
+        self.desired_none_is_valid = False
+        self.reported_none_is_valid = False
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['desired', 'reported'], args):

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -1272,13 +1272,7 @@ class ShadowMetadata(awsiot.ModeledClass):
 
     def __init__(self, *args, **kwargs):
         self.desired = kwargs.get('desired')
-        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
-        if (self.desired == None):
-            self.desired = {}
         self.reported = kwargs.get('reported')
-        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
-        if (self.reported == None):
-            self.reported = {}
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['desired', 'reported'], args):
@@ -1309,20 +1303,21 @@ class ShadowState(awsiot.ModeledClass):
 
     Attributes:
         desired (typing.Dict[str, typing.Any]): The desired shadow state (from external services and devices).
+        desired_none_is_valid (bool): Set to true to allow desired to be None, clearing the data if sent.
+
         reported (typing.Dict[str, typing.Any]): The (last) reported shadow state from the device.
+        reported_none_is_valid (bool): Set to true to allow reported to be None, clearing the data if sent.
+
     """
 
-    __slots__ = ['desired', 'reported']
+    __slots__ = ['desired', 'desired_none_is_valid', 'reported', 'reported_none_is_valid']
 
     def __init__(self, *args, **kwargs):
         self.desired = kwargs.get('desired')
-        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
-        if (self.desired == None):
-            self.desired = {}
         self.reported = kwargs.get('reported')
-        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
-        if (self.reported == None):
-            self.reported = {}
+
+        self.desired_none_is_valid = kwargs.get('desired_none_is_valid')
+        self.reported_none_is_valid = kwargs.get('reported_none_is_valid')
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['desired', 'reported'], args):
@@ -1344,11 +1339,17 @@ class ShadowState(awsiot.ModeledClass):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
 
-        if self.desired is not {}:
+        if self.desired_none_is_valid is True:
             payload['desired'] = self.desired
+        else:
+            if self.desired is not None:
+                payload['desired'] = self.desired
 
-        if self.reported is not {}:
+        if self.reported_none_is_valid is True:
             payload['reported'] = self.reported
+        else:
+            if self.reported is not None:
+                payload['reported'] = self.reported
 
         return payload
 
@@ -1375,13 +1376,7 @@ class ShadowStateWithDelta(awsiot.ModeledClass):
     def __init__(self, *args, **kwargs):
         self.delta = kwargs.get('delta')
         self.desired = kwargs.get('desired')
-        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
-        if (self.desired == None):
-            self.desired = {}
         self.reported = kwargs.get('reported')
-        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
-        if (self.reported == None):
-            self.reported = {}
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['delta', 'desired', 'reported'], args):

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -1303,21 +1303,21 @@ class ShadowState(awsiot.ModeledClass):
 
     Attributes:
         desired (typing.Dict[str, typing.Any]): The desired shadow state (from external services and devices).
-        desired_none_is_valid (bool): Set to true to allow 'desired' to be None, clearing the data if sent.
+        desired_is_nullable (bool): Set to true to allow 'desired' to be None, clearing the data if sent.
 
         reported (typing.Dict[str, typing.Any]): The (last) reported shadow state from the device.
-        reported_none_is_valid (bool): Set to true to allow 'reported' to be None, clearing the data if sent.
+        reported_is_nullable (bool): Set to true to allow 'reported' to be None, clearing the data if sent.
 
     """
 
-    __slots__ = ['desired', 'desired_none_is_valid', 'reported', 'reported_none_is_valid']
+    __slots__ = ['desired', 'desired_is_nullable', 'reported', 'reported_is_nullable']
 
     def __init__(self, *args, **kwargs):
         self.desired = kwargs.get('desired')
         self.reported = kwargs.get('reported')
 
-        self.desired_none_is_valid = kwargs.get('desired', False)
-        self.reported_none_is_valid = kwargs.get('reported', False)
+        self.desired_is_nullable = kwargs.get('desired_is_nullable', False)
+        self.reported_is_nullable = kwargs.get('reported_is_nullable', False)
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['desired', 'reported'], args):
@@ -1333,19 +1333,23 @@ class ShadowState(awsiot.ModeledClass):
         val = payload.get('reported')
         if val is not None:
             new.reported = val
+        if new.desired == None:
+            new.desired_is_nullable = True
+        if new.reported == None:
+            new.reported_is_nullable = True
         return new
 
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
 
-        if self.desired_none_is_valid is True:
+        if self.desired_is_nullable is True:
             payload['desired'] = self.desired
         else:
             if self.desired is not None:
                 payload['desired'] = self.desired
 
-        if self.reported_none_is_valid is True:
+        if self.reported_is_nullable is True:
             payload['reported'] = self.reported
         else:
             if self.reported is not None:

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -765,8 +765,10 @@ class DeleteNamedShadowRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
             payload['clientToken'] = self.client_token
+
         return payload
 
 class DeleteNamedShadowSubscriptionRequest(awsiot.ModeledClass):
@@ -824,8 +826,10 @@ class DeleteShadowRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
             payload['clientToken'] = self.client_token
+
         return payload
 
 class DeleteShadowResponse(awsiot.ModeledClass):
@@ -977,8 +981,10 @@ class GetNamedShadowRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
             payload['clientToken'] = self.client_token
+
         return payload
 
 class GetNamedShadowSubscriptionRequest(awsiot.ModeledClass):
@@ -1036,8 +1042,10 @@ class GetShadowRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
             payload['clientToken'] = self.client_token
+
         return payload
 
 class GetShadowResponse(awsiot.ModeledClass):
@@ -1264,7 +1272,13 @@ class ShadowMetadata(awsiot.ModeledClass):
 
     def __init__(self, *args, **kwargs):
         self.desired = kwargs.get('desired')
+        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
+        if (self.desired == None):
+            self.desired = {}
         self.reported = kwargs.get('reported')
+        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
+        if (self.reported == None):
+            self.reported = {}
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['desired', 'reported'], args):
@@ -1302,7 +1316,13 @@ class ShadowState(awsiot.ModeledClass):
 
     def __init__(self, *args, **kwargs):
         self.desired = kwargs.get('desired')
+        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
+        if (self.desired == None):
+            self.desired = {}
         self.reported = kwargs.get('reported')
+        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
+        if (self.reported == None):
+            self.reported = {}
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['desired', 'reported'], args):
@@ -1323,10 +1343,13 @@ class ShadowState(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
-        if self.desired is not None:
+
+        if self.desired is not {}:
             payload['desired'] = self.desired
-        if self.reported is not None:
+
+        if self.reported is not {}:
             payload['reported'] = self.reported
+
         return payload
 
 class ShadowStateWithDelta(awsiot.ModeledClass):
@@ -1352,7 +1375,13 @@ class ShadowStateWithDelta(awsiot.ModeledClass):
     def __init__(self, *args, **kwargs):
         self.delta = kwargs.get('delta')
         self.desired = kwargs.get('desired')
+        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
+        if (self.desired == None):
+            self.desired = {}
         self.reported = kwargs.get('reported')
+        # If uninitialized, set to an empty dictionary so it is possible to set it to None after initialization to clear the property.
+        if (self.reported == None):
+            self.reported = {}
 
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['delta', 'desired', 'reported'], args):
@@ -1522,12 +1551,16 @@ class UpdateNamedShadowRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
             payload['clientToken'] = self.client_token
+
         if self.state is not None:
             payload['state'] = self.state.to_payload()
+
         if self.version is not None:
             payload['version'] = self.version
+
         return payload
 
 class UpdateNamedShadowSubscriptionRequest(awsiot.ModeledClass):
@@ -1591,12 +1624,16 @@ class UpdateShadowRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
             payload['clientToken'] = self.client_token
+
         if self.state is not None:
             payload['state'] = self.state.to_payload()
+
         if self.version is not None:
             payload['version'] = self.version
+
         return payload
 
 class UpdateShadowResponse(awsiot.ModeledClass):

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -248,9 +248,7 @@ def change_shadow_value(value):
         # for both reported and desired to clear the shadow document completely
         # of both.
         if value == "clear_shadow":
-            tmp_state = iotshadow.ShadowState()
-            tmp_state.reported = None
-            tmp_state.desired = None
+            tmp_state = iotshadow.ShadowState(reported=None, desired=None, reported_none_is_valid=False, desired_none_is_valid=True)
             request = iotshadow.UpdateShadowRequest(
                 thing_name=thing_name,
                 state=tmp_state,

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -192,10 +192,16 @@ def on_update_shadow_accepted(response):
                 return
 
         try:
-            print("Finished updating reported shadow value to '{}'.".format(response.state.reported[shadow_property])) # type: ignore
+            if response.state.reported != None:
+                if shadow_property in response.state.reported:
+                    print("Finished updating reported shadow value to '{}'.".format(response.state.reported[shadow_property])) # type: ignore
+                else:
+                    print ("Could not find shadow property with name: '{}'.".format(shadow_property)) # type: ignore
+            else:
+                print("Shadow states cleared.") # when the shadow states are cleared, reported and desired are set to None
             print("Enter desired value: ") # remind user they can input new values
         except:
-            exit("Updated shadow is missing the target property.")
+            exit("Updated shadow is missing the target property")
 
     except Exception as e:
         exit(e)
@@ -238,14 +244,34 @@ def change_shadow_value(value):
         # any "response" messages received on the /accepted and /rejected topics
         token = str(uuid4())
 
-        request = iotshadow.UpdateShadowRequest(
+        # if the value is "clear shadow" then send a UpdateShadowRequest with None
+        # for both reported and desired to clear the shadow document completely
+        # of both.
+        if value == "clear_shadow":
+            tmp_state = iotshadow.ShadowState()
+            tmp_state.reported = None
+            tmp_state.desired = None
+            request = iotshadow.UpdateShadowRequest(
+                thing_name=thing_name,
+                state=tmp_state,
+                client_token=token,
+            )
+        # Otherwise, send a normal update request
+        else:
+            # if the value is "none" then set it to a Python none object to
+            # clear the individual shadow property
+            if value == "none":
+                value = None
+
+            request = iotshadow.UpdateShadowRequest(
             thing_name=thing_name,
             state=iotshadow.ShadowState(
                 reported={ shadow_property: value },
                 desired={ shadow_property: value },
-            ),
-            client_token=token,
-        )
+                ),
+                client_token=token,
+            )
+        
         future = shadow_client.publish_update_shadow(request, mqtt.QoS.AT_LEAST_ONCE)
 
         locked_data.request_tokens.add(token)

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -248,7 +248,7 @@ def change_shadow_value(value):
         # for both reported and desired to clear the shadow document completely
         # of both.
         if value == "clear_shadow":
-            tmp_state = iotshadow.ShadowState(reported=None, desired=None, reported_none_is_valid=False, desired_none_is_valid=True)
+            tmp_state = iotshadow.ShadowState(reported=None, desired=None, reported_is_nullable=True, desired_is_nullable=True)
             request = iotshadow.UpdateShadowRequest(
                 thing_name=thing_name,
                 state=tmp_state,


### PR DESCRIPTION
*Issue #, if available:*

Closes #114

*Description of changes:*

Adjusted the code for the ShadowState class so passing `None` is a valid input. This allows for clearing the `reported` or `desired` properties entirely in a method similar to the V1 SDK.

This PR makes the following changes:
* Adjusts the `iotshadow.py` file to allow for passing `none`.
  * Now the `desired` and `reported` fields are set to empty dictionaries on initialization rather than being set to `None`.
  * The code for sending the package check to see if `desired` or `reported` are equal to empty dictionaries instead of `None`.
* Adjusted the shadow sample
  * When you type `none`, it will now set the property to a Python `none` object, clearing the property with the shadow sample name.
  * When you type `clear_shadow`, it will send a ShadowState with both `reported` and `desired` set to `None`, clearing both entirely.
  * Additional conditions added to print a message based on the status of the shadow property in the `on_update_shadow_accepted` function.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
