### PR TITLE
fix: add close method to rpc client to close the connection

### DIFF
--- a/awsiot/eventstreamrpc.py
+++ b/awsiot/eventstreamrpc.py
@@ -821,6 +821,9 @@ class Client:
         self._connection = connection
         self._shape_index = shape_index
 
+    def close(self) -> Future:
+        return self._connection.close()
+
     def _new_operation(self, operation_type: type, stream_handler: StreamResponseHandler = None):
         return operation_type(stream_handler, self._shape_index, self._connection)
 

--- a/awsiot/eventstreamrpc.py
+++ b/awsiot/eventstreamrpc.py
@@ -821,8 +821,25 @@ class Client:
         self._connection = connection
         self._shape_index = shape_index
 
-    def close(self) -> Future:
-        return self._connection.close()
+    def close(self, reason: Optional[Exception] = None) -> Future:
+        """
+        Close the connection.
+
+        Shutdown is asynchronous. This call has no effect if the connection
+        is already closed or closing.
+
+        Args:
+            reason: If set, the connection will
+                close with this error as the reason (unless
+                it was already closing for another reason).
+
+        Returns:
+            The future which will complete
+            when the shutdown process is done. The future will have an
+            exception if shutdown was caused by an error, or a result
+            of None if the shutdown was clean and user-initiated.
+        """
+        return self._connection.close(reason=reason)
 
     def _new_operation(self, operation_type: type, stream_handler: StreamResponseHandler = None):
         return operation_type(stream_handler, self._shape_index, self._connection)

--- a/awsiot/greengrasscoreipc/clientv2.py
+++ b/awsiot/greengrasscoreipc/clientv2.py
@@ -39,6 +39,19 @@ class GreengrassCoreIPCClientV2:
         self.executor = executor
 
     def close(self, *, executor_wait=True) -> concurrent.futures.Future:
+        """
+        Close the underlying connection and shutdown the event executor (if any)
+
+        Args:
+            executor_wait: If true (default), then this method will block until the executor finishes running
+                all tasks and shuts down.
+
+        Returns:
+            The future which will complete
+            when the shutdown process is done. The future will have an
+            exception if shutdown was caused by an error, or a result
+            of None if the shutdown was clean and user-initiated.
+        """
         fut = self.client.close()
         if self.executor is not None:
             self.executor.shutdown(wait=executor_wait)

--- a/awsiot/greengrasscoreipc/clientv2.py
+++ b/awsiot/greengrasscoreipc/clientv2.py
@@ -38,6 +38,12 @@ class GreengrassCoreIPCClientV2:
             executor = concurrent.futures.ThreadPoolExecutor()
         self.executor = executor
 
+    def close(self, *, executor_wait=True) -> concurrent.futures.Future:
+        fut = self.client.close()
+        if self.executor is not None:
+            self.executor.shutdown(wait=executor_wait)
+        return fut
+
     def __combine_futures(self, future1: concurrent.futures.Future,
                           future2: concurrent.futures.Future) -> concurrent.futures.Future:
         def callback(*args, **kwargs):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds close method to rpc Client and adds and uses that close method in the Greengrass V2 client.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
