### PR TITLE
GGV2 client: add exception logging so that errors are always visible,…

### DIFF
--- a/awsiot/greengrasscoreipc/client.py
+++ b/awsiot/greengrasscoreipc/client.py
@@ -1109,7 +1109,7 @@ class GreengrassCoreIPCClient(rpc.Client):
     """
     Client for the GreengrassCoreIPC service.
     There is a new V2 client available for testing in developer preview.
-    See the GreengrassCoreIPCClientV2 class.
+    See the GreengrassCoreIPCClientV2 class in the clientv2 subpackage.
 
     Args:
         connection: Connection that this client will use.


### PR DESCRIPTION
… even when using executors

*Issue #, if available:*

*Description of changes:*
Wraps the user-provided methods with try/except + logging to stderr so that unhandled exceptions won't be invisible. If the user properly catches any exceptions, then this new handling won't ever be triggered. This handler is just intended to make any programming errors more visible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
