### PR TITLE
Fix continuous delivery using wrong argument names in test

### DIFF
--- a/continuous-delivery/test_prod_pypi.yml
+++ b/continuous-delivery/test_prod_pypi.yml
@@ -20,7 +20,7 @@ phases:
       - cd aws-iot-device-sdk-python-v2
       - CURRENT_TAG_VERSION=$(git describe --tags | cut -f2 -dv)
       - python3 continuous-delivery/pip-install-with-retry.py --no-cache-dir --user awsiotsdk==$CURRENT_TAG_VERSION
-      - python3 samples/basic_discovery.py --region us-east-1 --cert /tmp/certificate.pem --key /tmp/privatekey.pem --root-ca /tmp/AmazonRootCA1.pem --thing-name aws-sdk-crt-unit-test --print-discover-resp-only -v Trace
+      - python3 samples/basic_discovery.py --region us-east-1 --cert /tmp/certificate.pem --key /tmp/privatekey.pem --ca_file /tmp/AmazonRootCA1.pem --thing_name aws-sdk-crt-unit-test --print_discover_resp_only -v Trace
 
   post_build:
     commands:

--- a/continuous-delivery/test_test_pypi.yml
+++ b/continuous-delivery/test_test_pypi.yml
@@ -22,7 +22,7 @@ phases:
       # this is here because typing isn't in testpypi, so pull it from prod instead
       - python3 -m pip install typing
       - python3 continuous-delivery/pip-install-with-retry.py -i https://testpypi.python.org/simple --user awsiotsdk==$CURRENT_TAG_VERSION
-      - python3 samples/basic_discovery.py --region us-east-1 --cert /tmp/certificate.pem --key /tmp/privatekey.pem --root-ca /tmp/AmazonRootCA1.pem --thing-name aws-sdk-crt-unit-test --print-discover-resp-only -v Trace
+      - python3 samples/basic_discovery.py --region us-east-1 --cert /tmp/certificate.pem --key /tmp/privatekey.pem --ca_file /tmp/AmazonRootCA1.pem --thing_name aws-sdk-crt-unit-test --print_discover_resp_only -v Trace
 
   post_build:
     commands:


### PR DESCRIPTION
*Description of changes:*

Fixes the continuous delivery failing due to the samples being passed the wrong arguments when I updated the argument names.

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
