### PR TITLE
Add ECC support for PKCS#11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.13.6',
+        'awscrt==0.13.9',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
functionality comes from updated awcrt dependency.

**Issue #:**
https://github.com/aws/aws-iot-device-sdk-python-v2/issues/295

Co-authored-by: @JamieHunter 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
