### PR TITLE
Fix pkcs11_connect.py sample

### DIFF
--- a/codebuild/samples/linux-smoke-tests.yml
+++ b/codebuild/samples/linux-smoke-tests.yml
@@ -4,12 +4,13 @@ phases:
     commands:
       - add-apt-repository ppa:ubuntu-toolchain-r/test
       - apt-get update -y
-      - apt-get install python3 -y
+      - apt-get install python3 softhsm -y
   build:
     commands:
       - echo Build started on `date`
       - $CODEBUILD_SRC_DIR/codebuild/samples/setup-linux.sh
       - $CODEBUILD_SRC_DIR/codebuild/samples/connect-linux.sh
+      - $CODEBUILD_SRC_DIR/codebuild/samples/pkcs11-connect-linux.sh
       - $CODEBUILD_SRC_DIR/codebuild/samples/pubsub-linux.sh
   post_build:
     commands:

--- a/codebuild/samples/pkcs11-connect-linux.sh
+++ b/codebuild/samples/pkcs11-connect-linux.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+pushd $CODEBUILD_SRC_DIR/samples/
+
+ENDPOINT=$(aws secretsmanager get-secret-value --secret-id "unit-test/endpoint" --query "SecretString" | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
+
+# from hereon commands are echoed. don't leak secrets
+set -x
+
+softhsm2-util --version
+
+# SoftHSM2's default tokendir path might be invalid on this machine
+# so set up a conf file that specifies a known good tokendir path
+mkdir -p /tmp/tokens
+export SOFTHSM2_CONF=/tmp/softhsm2.conf
+echo "directories.tokendir = /tmp/tokens" > /tmp/softhsm2.conf
+
+# create token
+softhsm2-util --init-token --free --label my-token --pin 0000 --so-pin 0000
+
+# add private key to token (must be in PKCS#8 format)
+openssl pkcs8 -topk8 -in /tmp/privatekey.pem -out /tmp/privatekey.p8.pem -nocrypt
+softhsm2-util --import /tmp/privatekey.p8.pem --token my-token --label my-key --id BEEFCAFE --pin 0000
+
+# run sample
+python3 pkcs11_connect.py \
+    --endpoint $ENDPOINT \
+    --cert /tmp/certificate.pem \
+    --pkcs11_lib /usr/lib/softhsm/libsofthsm2.so \
+    --pin 0000 \
+    --token_label my-token \
+    --key_label my-key
+
+popd

--- a/samples/command_line_utils.py
+++ b/samples/command_line_utils.py
@@ -127,6 +127,7 @@ class CommandLineUtils:
             client_id=self.get_command_required("client_id"),
             clean_session=False,
             keep_alive_secs=30)
+        return mqtt_connection
 
     def build_websocket_mqtt_connection(self, on_connection_interrupted, on_connection_resumed):
         proxy_options = self.get_proxy_options_for_mqtt_connection()

--- a/samples/pkcs11_connect.py
+++ b/samples/pkcs11_connect.py
@@ -47,7 +47,7 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 if __name__ == '__main__':
     # Create a connection using websockets.
     # Note: The data for the connection is gotten from cmdUtils.
-    # (see build_websocket_mqtt_connection for implementation)
+    # (see build_pkcs11_mqtt_connection for implementation)
     mqtt_connection = cmdUtils.build_pkcs11_mqtt_connection(on_connection_interrupted, on_connection_resumed)
 
     print("Connecting to {} with client ID '{}'...".format(


### PR DESCRIPTION
**Issue:**
pkcs11_connect.py sample is broken: https://github.com/aws/aws-iot-device-sdk-python-v2/issues/309

**Diagnosis:**
This wasn't tested as part of CI, so a trivial accident while refactoring the samples wasn't caught.

**Changes:**
Add missing `return` statement. Also, add pkcs11_connect.py sample to our CI so we catch any future breaks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
