### PR TITLE
Improved support for Apple Silicon aka M1 aka arm64 aka Universal2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.13.9',
+        'awscrt==0.13.11',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-python-v2/issues/286

*Description of changes:*
Use latest version of awscrt, which has wheels that work properly on M1 macs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
