### PR TITLE
Added custom authorizer sample

### DIFF
--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -427,15 +427,16 @@ def websockets_with_custom_handshake(
                     websocket_proxy_options=websocket_proxy_options,
                     **kwargs)
 
-def _add_username_parameter(input_string, parameter_value, parameter_pretext, added_string_to_username):
+def _add_to_username_parameter(input_string, parameter_value, parameter_pretext):
     """
     Helper function to add parameters to the username in the direct_with_custom_authorizer function
     """
     return_string = input_string
-    if added_string_to_username is False:
-        return_string += "?"
-    else:
+
+    if not return_string.find("?") is -1:
         return_string += "&"
+    else:
+        return_string += "?"
 
     if not parameter_value.find(parameter_pretext) is -1:
         return return_string + parameter_value
@@ -474,7 +475,6 @@ def direct_with_custom_authorizer(
 
     _check_required_kwargs(**kwargs)
     username_string = ""
-    added_string_to_username = False
 
     if auth_username is None:
         if not _get(kwargs, "username") is None:
@@ -483,12 +483,11 @@ def direct_with_custom_authorizer(
         username_string += auth_username
 
     if not auth_authorizer_name is None:
-        username_string = _add_username_parameter(
-            username_string, auth_authorizer_name, "x-amz-customauthorizer-name=", added_string_to_username)
-        added_string_to_username = True
+        username_string = _add_to_username_parameter(
+            username_string, auth_authorizer_name, "x-amz-customauthorizer-name=")
     if not auth_authorizer_signature is None:
-        username_string = _add_username_parameter(
-            username_string, auth_authorizer_signature, "x-amz-customauthorizer-signature=", added_string_to_username)
+        username_string = _add_to_username_parameter(
+            username_string, auth_authorizer_signature, "x-amz-customauthorizer-signature=")
 
     kwargs["username"] = username_string
     kwargs["password"] = auth_password

--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -456,19 +456,19 @@ def direct_with_custom_authorizer(
     described at the top of this doc, as well as...
 
     Keyword Args:
-        auth_username (String): The username to use with the custom authorizer.
+        auth_username (`str`): The username to use with the custom authorizer.
             If provided, the username given will be passed when connecting to the custom authorizer.
             If not provided, it will check to see if a username has already been set (via username="example")
             and will use that instead.
             If no username has been set then no username will be sent with the MQTT connection.
 
-        auth_authorizer_name (String):  The name of the custom authorizer.
+        auth_authorizer_name (`str`):  The name of the custom authorizer.
             If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
 
-        auth_authorizer_signature (String):  The signature of the custom authorizer.
+        auth_authorizer_signature (`str`):  The signature of the custom authorizer.
             If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
 
-        auth_password (String):  The password to use with the custom authorizer.
+        auth_password (`str`):  The password to use with the custom authorizer.
             If not provided, then no passord will be set.
     """
 

--- a/codebuild/samples/connect-auth-linux.sh
+++ b/codebuild/samples/connect-auth-linux.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+env
+
+pushd $CODEBUILD_SRC_DIR/samples/
+
+ENDPOINT=$(aws secretsmanager get-secret-value --secret-id "unit-test/endpoint" --query "SecretString" | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
+AUTH_NAME=$(aws secretsmanager get-secret-value --secret-id "unit-test/authorizer-name" --query "SecretString" | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
+AUTH_PASSWORD=$(aws secretsmanager get-secret-value --secret-id "unit-test/authorizer-password" --query "SecretString" | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
+
+echo "Custom authorizer connect test"
+python3 custom_authorizer_connect.py --endpoint $ENDPOINT --custom_auth_authorizer_name $AUTH_NAME --custom_auth_password $AUTH_PASSWORD
+
+popd

--- a/codebuild/samples/linux-smoke-tests.yml
+++ b/codebuild/samples/linux-smoke-tests.yml
@@ -12,6 +12,7 @@ phases:
       - $CODEBUILD_SRC_DIR/codebuild/samples/connect-linux.sh
       - $CODEBUILD_SRC_DIR/codebuild/samples/pkcs11-connect-linux.sh
       - $CODEBUILD_SRC_DIR/codebuild/samples/pubsub-linux.sh
+      - $CODEBUILD_SRC_DIR/codebuild/samples/connect-auth-linux.sh
   post_build:
     commands:
       - echo Build completed on `date`

--- a/samples/README.md
+++ b/samples/README.md
@@ -5,6 +5,7 @@
 * [Websocket Connect](#websocket-connect)
 * [PKCS#11 Connect](#pkcs11-connect)
 * [Windows Certificate Connect](#windows-certificate-connect)
+* [Custom Authorizer Connect](#custom-authorizer-connect)
 * [Shadow](#shadow)
 * [Jobs](#jobs)
 * [Fleet Provisioning](#fleet-provisioning)
@@ -323,6 +324,39 @@ To run this sample with a basic certificate from AWS IoT Core:
     ```sh
     python3 windows_cert_connect.py --endpoint <endpoint> --ca_file <path to root CA> --cert <path to certificate>
     ```
+
+## Custom Authorizer Connect
+
+This sample makes an MQTT connection and connects through a [Custom Authorizer](https://docs.aws.amazon.com/iot/latest/developerguide/custom-authentication.html). On startup, the device connects to the server and then disconnects. This sample is for reference on connecting using a custom authorizer.
+
+Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect.
+
+<details>
+<summary>(see sample policy)</summary>
+<pre>
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Connect"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
+      ]
+    }
+  ]
+}
+</pre>
+</details>
+
+Run the sample like this:
+``` sh
+python3 custom_authorizer_connect.py --endpoint <endpoint> --ca_file <path to root CA> --custom_auth_authorizer_name <authorizer name>
+```
+
+You will need to setup your Custom Authorizer so that the lambda function returns a policy document. See [this page on the documentation](https://docs.aws.amazon.com/iot/latest/developerguide/config-custom-auth.html) for more details and example return result.
 
 ## Shadow
 

--- a/samples/command_line_utils.py
+++ b/samples/command_line_utils.py
@@ -81,7 +81,7 @@ class CommandLineUtils:
         self.register_command(self.m_cmd_custom_auth_username, "<str>", "The name to send when connecting through the custom authorizer (optional)")
         self.register_command(self.m_cmd_custom_auth_authorizer_name, "<str>", "The name of the custom authorizer to connect to (optional but required for everything but custom domains)")
         self.register_command(self.m_cmd_custom_auth_username, "<str>", "The signature to send when connecting through a custom authorizer (optional)")
-        self.register_command(self.m_cmd_custom_auth_username, "<str>", "The password to send when connecting through a custom authorizer (optional)")
+        self.register_command(self.m_cmd_custom_auth_password, "<str>", "The password to send when connecting through a custom authorizer (optional)")
 
     """
     Returns the command if it exists and has been passed to the console, otherwise it will print the help for the sample and exit the application.

--- a/samples/command_line_utils.py
+++ b/samples/command_line_utils.py
@@ -77,6 +77,12 @@ class CommandLineUtils:
     def add_common_logging_commands(self):
         self.register_command(self.m_cmd_verbosity, "<Log Level>", "Logging level.", default=io.LogLevel.NoLogs.name, choices=[x.name for x in io.LogLevel])
 
+    def add_common_custom_authorizer_commands(self):
+        self.register_command(self.m_cmd_custom_auth_username, "<str>", "The name to send when connecting through the custom authorizer (optional)")
+        self.register_command(self.m_cmd_custom_auth_authorizer_name, "<str>", "The name of the custom authorizer to connect to (optional but required for everything but custom domains)")
+        self.register_command(self.m_cmd_custom_auth_username, "<str>", "The signature to send when connecting through a custom authorizer (optional)")
+        self.register_command(self.m_cmd_custom_auth_username, "<str>", "The password to send when connecting through a custom authorizer (optional)")
+
     """
     Returns the command if it exists and has been passed to the console, otherwise it will print the help for the sample and exit the application.
     """
@@ -191,3 +197,7 @@ class CommandLineUtils:
     m_cmd_message = "message"
     m_cmd_topic = "topic"
     m_cmd_verbosity = "verbosity"
+    m_cmd_custom_auth_username = "custom_auth_username"
+    m_cmd_custom_auth_authorizer_name = "custom_auth_authorizer_name"
+    m_cmd_custom_auth_authorizer_signature = "custom_auth_authorizer_signature"
+    m_cmd_custom_auth_password = "custom_auth_password"

--- a/samples/custom_authorizer_connect.py
+++ b/samples/custom_authorizer_connect.py
@@ -4,19 +4,16 @@
 from awsiot import mqtt_connection_builder
 from uuid import uuid4
 
-# This sample is similar to `samples/basic_connect.py` but the certificate
-# for mutual TLS is stored in a Windows certificate store.
-#
-# See `samples/README.md` for instructions on setting up your PC
-# to run this sample.
-#
-# WARNING: Windows only.
+# This sample is similar to `samples/basic_connect.py` but it connects
+# through a custom authorizer rather than using a key and certificate.
 
 # Parse arguments
 import command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("Windows Cert Connect - Make a MQTT connection using Windows Store Certificates.")
+cmdUtils = command_line_utils.CommandLineUtils(
+    "Custom Authorizer Connect - Make a MQTT connection using a custom authorizer.")
 cmdUtils.add_common_mqtt_commands()
 cmdUtils.add_common_logging_commands()
+cmdUtils.add_common_custom_authorizer_commands()
 cmdUtils.register_command("client_id", "<str>",
                           "Client ID to use for MQTT connection (optional, default='test-*').",
                           default="test-" + str(uuid4()))
@@ -35,12 +32,15 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 
 
 if __name__ == '__main__':
-    # Create MQTT connection
-    mqtt_connection = mqtt_connection_builder.mtls_with_windows_cert_store_path(
-        cert_store_path=cmdUtils.get_command_required("cert"),
+
+    # Create MQTT connection with a custom authorizer
+    mqtt_connection = mqtt_connection_builder.direct_with_custom_authorizer(
         endpoint=cmdUtils.get_command_required(cmdUtils.m_cmd_endpoint),
-        port=cmdUtils.get_command("port"),
         ca_filepath=cmdUtils.get_command(cmdUtils.m_cmd_ca_file),
+        auth_username=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_username),
+        auth_authorizer_name=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_authorizer_name),
+        auth_authorizer_signature=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_authorizer_signature),
+        auth_password=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_password),
         on_connection_interrupted=on_connection_interrupted,
         on_connection_resumed=on_connection_resumed,
         client_id=cmdUtils.get_command("client_id"),


### PR DESCRIPTION
*Description of changes:*

Adds a custom authorizer sample, following the same format as the Java V2 custom authorizer sample. 

Also modifies the MQTT connection builder code so it is possible to easily make a custom authorizer connection, and modifies adding the SDK metrics to the username so it correctly adds it to the end of the username if the username is a query string.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
