### PR TITLE
Fix to_payload and from_payload model generation names

### DIFF
--- a/awsiot/iotidentity.py
+++ b/awsiot/iotidentity.py
@@ -309,8 +309,10 @@ class CreateCertificateFromCsrRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.certificate_signing_request is not None:
-            payload['certificateSigningRequest'] = self.certificate_signing_request
+            payload['certificate_signing_request'] = self.certificate_signing_request
+
         return payload
 
 class CreateCertificateFromCsrResponse(awsiot.ModeledClass):
@@ -346,13 +348,13 @@ class CreateCertificateFromCsrResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> CreateCertificateFromCsrResponse
         new = cls()
-        val = payload.get('certificateId')
+        val = payload.get('certificate_id')
         if val is not None:
             new.certificate_id = val
-        val = payload.get('certificateOwnershipToken')
+        val = payload.get('certificate_ownership_token')
         if val is not None:
             new.certificate_ownership_token = val
-        val = payload.get('certificatePem')
+        val = payload.get('certificate_pem')
         if val is not None:
             new.certificate_pem = val
         return new
@@ -425,16 +427,16 @@ class CreateKeysAndCertificateResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> CreateKeysAndCertificateResponse
         new = cls()
-        val = payload.get('certificateId')
+        val = payload.get('certificate_id')
         if val is not None:
             new.certificate_id = val
-        val = payload.get('certificateOwnershipToken')
+        val = payload.get('certificate_ownership_token')
         if val is not None:
             new.certificate_ownership_token = val
-        val = payload.get('certificatePem')
+        val = payload.get('certificate_pem')
         if val is not None:
             new.certificate_pem = val
-        val = payload.get('privateKey')
+        val = payload.get('private_key')
         if val is not None:
             new.private_key = val
         return new
@@ -488,13 +490,13 @@ class ErrorResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> ErrorResponse
         new = cls()
-        val = payload.get('errorCode')
+        val = payload.get('error_code')
         if val is not None:
             new.error_code = val
-        val = payload.get('errorMessage')
+        val = payload.get('error_message')
         if val is not None:
             new.error_message = val
-        val = payload.get('statusCode')
+        val = payload.get('status_code')
         if val is not None:
             new.status_code = val
         return new
@@ -531,10 +533,13 @@ class RegisterThingRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.certificate_ownership_token is not None:
-            payload['certificateOwnershipToken'] = self.certificate_ownership_token
+            payload['certificate_ownership_token'] = self.certificate_ownership_token
+
         if self.parameters is not None:
             payload['parameters'] = self.parameters
+
         return payload
 
 class RegisterThingResponse(awsiot.ModeledClass):
@@ -567,10 +572,10 @@ class RegisterThingResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> RegisterThingResponse
         new = cls()
-        val = payload.get('deviceConfiguration')
+        val = payload.get('device_configuration')
         if val is not None:
             new.device_configuration = val
-        val = payload.get('thingName')
+        val = payload.get('thing_name')
         if val is not None:
             new.thing_name = val
         return new

--- a/awsiot/iotjobs.py
+++ b/awsiot/iotjobs.py
@@ -505,12 +505,16 @@ class DescribeJobExecutionRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
+
         if self.execution_number is not None:
-            payload['executionNumber'] = self.execution_number
+            payload['execution_number'] = self.execution_number
+
         if self.include_job_document is not None:
-            payload['includeJobDocument'] = self.include_job_document
+            payload['include_job_document'] = self.include_job_document
+
         return payload
 
 class DescribeJobExecutionResponse(awsiot.ModeledClass):
@@ -546,7 +550,7 @@ class DescribeJobExecutionResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> DescribeJobExecutionResponse
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
         val = payload.get('execution')
@@ -612,8 +616,10 @@ class GetPendingJobExecutionsRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
+
         return payload
 
 class GetPendingJobExecutionsResponse(awsiot.ModeledClass):
@@ -652,13 +658,13 @@ class GetPendingJobExecutionsResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> GetPendingJobExecutionsResponse
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
-        val = payload.get('inProgressJobs')
+        val = payload.get('in_progress_jobs')
         if val is not None:
             new.in_progress_jobs = [JobExecutionSummary.from_payload(i) for i in val]
-        val = payload.get('queuedJobs')
+        val = payload.get('queued_jobs')
         if val is not None:
             new.queued_jobs = [JobExecutionSummary.from_payload(i) for i in val]
         val = payload.get('timestamp')
@@ -743,34 +749,34 @@ class JobExecutionData(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> JobExecutionData
         new = cls()
-        val = payload.get('executionNumber')
+        val = payload.get('execution_number')
         if val is not None:
             new.execution_number = val
-        val = payload.get('jobDocument')
+        val = payload.get('job_document')
         if val is not None:
             new.job_document = val
-        val = payload.get('jobId')
+        val = payload.get('job_id')
         if val is not None:
             new.job_id = val
-        val = payload.get('lastUpdatedAt')
+        val = payload.get('last_updated_at')
         if val is not None:
             new.last_updated_at = datetime.datetime.fromtimestamp(val)
-        val = payload.get('queuedAt')
+        val = payload.get('queued_at')
         if val is not None:
             new.queued_at = datetime.datetime.fromtimestamp(val)
-        val = payload.get('startedAt')
+        val = payload.get('started_at')
         if val is not None:
             new.started_at = datetime.datetime.fromtimestamp(val)
         val = payload.get('status')
         if val is not None:
             new.status = val
-        val = payload.get('statusDetails')
+        val = payload.get('status_details')
         if val is not None:
             new.status_details = val
-        val = payload.get('thingName')
+        val = payload.get('thing_name')
         if val is not None:
             new.thing_name = val
-        val = payload.get('versionNumber')
+        val = payload.get('version_number')
         if val is not None:
             new.version_number = val
         return new
@@ -811,10 +817,10 @@ class JobExecutionState(awsiot.ModeledClass):
         val = payload.get('status')
         if val is not None:
             new.status = val
-        val = payload.get('statusDetails')
+        val = payload.get('status_details')
         if val is not None:
             new.status_details = val
-        val = payload.get('versionNumber')
+        val = payload.get('version_number')
         if val is not None:
             new.version_number = val
         return new
@@ -861,22 +867,22 @@ class JobExecutionSummary(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> JobExecutionSummary
         new = cls()
-        val = payload.get('executionNumber')
+        val = payload.get('execution_number')
         if val is not None:
             new.execution_number = val
-        val = payload.get('jobId')
+        val = payload.get('job_id')
         if val is not None:
             new.job_id = val
-        val = payload.get('lastUpdatedAt')
+        val = payload.get('last_updated_at')
         if val is not None:
             new.last_updated_at = datetime.datetime.fromtimestamp(val)
-        val = payload.get('queuedAt')
+        val = payload.get('queued_at')
         if val is not None:
             new.queued_at = datetime.datetime.fromtimestamp(val)
-        val = payload.get('startedAt')
+        val = payload.get('started_at')
         if val is not None:
             new.started_at = datetime.datetime.fromtimestamp(val)
-        val = payload.get('versionNumber')
+        val = payload.get('version_number')
         if val is not None:
             new.version_number = val
         return new
@@ -1042,13 +1048,13 @@ class RejectedError(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> RejectedError
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
         val = payload.get('code')
         if val is not None:
             new.code = val
-        val = payload.get('executionState')
+        val = payload.get('execution_state')
         if val is not None:
             new.execution_state = JobExecutionState.from_payload(val)
         val = payload.get('message')
@@ -1092,7 +1098,7 @@ class StartNextJobExecutionResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> StartNextJobExecutionResponse
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
         val = payload.get('execution')
@@ -1138,12 +1144,16 @@ class StartNextPendingJobExecutionRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
+
         if self.status_details is not None:
-            payload['statusDetails'] = self.status_details
+            payload['status_details'] = self.status_details
+
         if self.step_timeout_in_minutes is not None:
-            payload['stepTimeoutInMinutes'] = self.step_timeout_in_minutes
+            payload['step_timeout_in_minutes'] = self.step_timeout_in_minutes
+
         return payload
 
 class StartNextPendingJobExecutionSubscriptionRequest(awsiot.ModeledClass):
@@ -1222,22 +1232,31 @@ class UpdateJobExecutionRequest(awsiot.ModeledClass):
     def to_payload(self):
         # type: () -> typing.Dict[str, typing.Any]
         payload = {} # type: typing.Dict[str, typing.Any]
+
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
+
         if self.execution_number is not None:
-            payload['executionNumber'] = self.execution_number
+            payload['execution_number'] = self.execution_number
+
         if self.expected_version is not None:
-            payload['expectedVersion'] = self.expected_version
+            payload['expected_version'] = self.expected_version
+
         if self.include_job_document is not None:
-            payload['includeJobDocument'] = self.include_job_document
+            payload['include_job_document'] = self.include_job_document
+
         if self.include_job_execution_state is not None:
-            payload['includeJobExecutionState'] = self.include_job_execution_state
+            payload['include_job_execution_state'] = self.include_job_execution_state
+
         if self.status is not None:
             payload['status'] = self.status
+
         if self.status_details is not None:
-            payload['statusDetails'] = self.status_details
+            payload['status_details'] = self.status_details
+
         if self.step_timeout_in_minutes is not None:
-            payload['stepTimeoutInMinutes'] = self.step_timeout_in_minutes
+            payload['step_timeout_in_minutes'] = self.step_timeout_in_minutes
+
         return payload
 
 class UpdateJobExecutionResponse(awsiot.ModeledClass):
@@ -1276,13 +1295,13 @@ class UpdateJobExecutionResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> UpdateJobExecutionResponse
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
-        val = payload.get('executionState')
+        val = payload.get('execution_state')
         if val is not None:
             new.execution_state = JobExecutionState.from_payload(val)
-        val = payload.get('jobDocument')
+        val = payload.get('job_document')
         if val is not None:
             new.job_document = val
         val = payload.get('timestamp')

--- a/awsiot/iotshadow.py
+++ b/awsiot/iotshadow.py
@@ -767,7 +767,7 @@ class DeleteNamedShadowRequest(awsiot.ModeledClass):
         payload = {} # type: typing.Dict[str, typing.Any]
 
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
 
         return payload
 
@@ -828,7 +828,7 @@ class DeleteShadowRequest(awsiot.ModeledClass):
         payload = {} # type: typing.Dict[str, typing.Any]
 
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
 
         return payload
 
@@ -865,7 +865,7 @@ class DeleteShadowResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> DeleteShadowResponse
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
         val = payload.get('timestamp')
@@ -935,7 +935,7 @@ class ErrorResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> ErrorResponse
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
         val = payload.get('code')
@@ -983,7 +983,7 @@ class GetNamedShadowRequest(awsiot.ModeledClass):
         payload = {} # type: typing.Dict[str, typing.Any]
 
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
 
         return payload
 
@@ -1044,7 +1044,7 @@ class GetShadowRequest(awsiot.ModeledClass):
         payload = {} # type: typing.Dict[str, typing.Any]
 
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
 
         return payload
 
@@ -1087,7 +1087,7 @@ class GetShadowResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> GetShadowResponse
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
         val = payload.get('metadata')
@@ -1218,7 +1218,7 @@ class ShadowDeltaUpdatedEvent(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> ShadowDeltaUpdatedEvent
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
         val = payload.get('metadata')
@@ -1556,7 +1556,7 @@ class UpdateNamedShadowRequest(awsiot.ModeledClass):
         payload = {} # type: typing.Dict[str, typing.Any]
 
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
 
         if self.state is not None:
             payload['state'] = self.state.to_payload()
@@ -1629,7 +1629,7 @@ class UpdateShadowRequest(awsiot.ModeledClass):
         payload = {} # type: typing.Dict[str, typing.Any]
 
         if self.client_token is not None:
-            payload['clientToken'] = self.client_token
+            payload['client_token'] = self.client_token
 
         if self.state is not None:
             payload['state'] = self.state.to_payload()
@@ -1678,7 +1678,7 @@ class UpdateShadowResponse(awsiot.ModeledClass):
     def from_payload(cls, payload):
         # type: (typing.Dict[str, typing.Any]) -> UpdateShadowResponse
         new = cls()
-        val = payload.get('clientToken')
+        val = payload.get('client_token')
         if val is not None:
             new.client_token = val
         val = payload.get('metadata')
@@ -1717,3 +1717,4 @@ class UpdateShadowSubscriptionRequest(awsiot.ModeledClass):
         # for backwards compatibility, read any arguments that used to be accepted by position
         for key, val in zip(['thing_name'], args):
             setattr(self, key, val)
+


### PR DESCRIPTION
*Description of changes:*

Fixes an issue with our model generation where properties composed of two words (like `ClientToken`) were incorrectly not converted to Python naming scheme (`client_token`).

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
