### PR TITLE
Bump Python CRT for better arm64 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.13.11',
+        'awscrt==0.13.13',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
*Description of changes:*

Changes from [PR #332](https://github.com/aws/aws-iot-device-sdk-python-v2/pull/322), but made as a branch so CI runs. Description from [#332](https://github.com/aws/aws-iot-device-sdk-python-v2/pull/322):

_________

The recent arm64 support for awscrt isn't working 100%.
I get the following with 0.13.11:

```
        building '_awscrt' extension
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-mqtt.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-http.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-s3.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-auth.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-event-stream.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-compression.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-checksums.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-cal.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-sdkutils.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-io.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
        ld: warning: ignoring file build/temp.macosx-10.14-arm64-3.8/deps/install/lib/libaws-c-common.a, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
```

The latest version of awscrt, 0.13.13 resolves this and it builds.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
