### PR TITLE
Avoid warnings for using 'is' with literals in python 3.8+

### DIFF
--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -131,7 +131,7 @@ def _get_metrics_str(current_username=""):
     global _metrics_str
 
     username_has_query = False
-    if not current_username.find("?") is -1:
+    if current_username.find("?") != -1:
         username_has_query = True
 
     if _metrics_str is None:
@@ -433,12 +433,12 @@ def _add_to_username_parameter(input_string, parameter_value, parameter_pretext)
     """
     return_string = input_string
 
-    if not return_string.find("?") is -1:
+    if return_string.find("?") != -1:
         return_string += "&"
     else:
         return_string += "?"
 
-    if not parameter_value.find(parameter_pretext) is -1:
+    if parameter_value.find(parameter_pretext) != -1:
         return return_string + parameter_value
     else:
         return return_string + parameter_pretext + parameter_value


### PR DESCRIPTION
*Description of changes:*

I'm currently seeing this in our Cloudwatch logs:

![Screenshot 2022-07-07 at 06 06 22](https://user-images.githubusercontent.com/7068515/177695723-72b3de50-fe63-4d42-83a7-5dc8397d86a2.png)

This is due to a change in python 3.8 that now reports syntax warnings for this use of `is`.

This PR updates `mqtt_connection_builder.py` to avoid warnings for using `is` with literals in comparisons for python 3.8+


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
