### PR TITLE
Fix kwargs in default builder not being unpacked correctly

### DIFF
--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -512,11 +512,11 @@ def new_default_builder(**kwargs) -> awscrt.mqtt.Connection:
     This builder creates an :class:`awscrt.mqtt.Connection`, without any configuration besides the default TLS context options.
 
     This requires setting the connection details manually by passing all the necessary data
-    in :mod:`common arguments<awsiot.mqtt_connection_builder>` to make a connection
+    in :mod:`common arguments<awsiot.mqtt_connection_builder>` to make a connection.
     """
-    _check_required_kwargs(kwargs)
+    _check_required_kwargs(**kwargs)
     tls_ctx_options = awscrt.io.TlsContextOptions()
 
     return _builder(tls_ctx_options=tls_ctx_options,
                     use_websockets=False,
-                    kwargs=kwargs)
+                    **kwargs)


### PR DESCRIPTION
*Issue #, if available:*

Closes #340 

*Description of changes:*

Fixes `kwargs` being passed as a single object rather than being unpacked when passed as an argument.

_____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
