### PR TITLE
update CRT to latest

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -47,7 +47,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # For cross-linking to types from other libraries
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'awscrt': ('https://awslabs.github.io/aws-crt-python/api', None),
+    'awscrt': ('https://awslabs.github.io/aws-crt-python', None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.13.14',
+        'awscrt==0.14.0',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
Pick up aws-c-common fix for dlopen usage from mac

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
