### PR TITLE
Fix PyPi release to use IoT specific token

### DIFF
--- a/continuous-delivery/publish_to_prod_pypi.yml
+++ b/continuous-delivery/publish_to_prod_pypi.yml
@@ -11,7 +11,7 @@ phases:
   pre_build:
     commands:
       - cd aws-iot-device-sdk-python-v2
-      - pypirc=$(aws secretsmanager get-secret-value --secret-id "prod/aws-crt-python/.pypirc" --query "SecretString" | cut -f2 -d\") && echo "$pypirc" > ~/.pypirc
+      - pypirc=$(aws secretsmanager get-secret-value --secret-id "prod/aws-sdk-python-v2/.pypirc" --query "SecretString" | cut -f2 -d\") && echo "$pypirc" > ~/.pypirc
       - export PKG_VERSION=$(git describe --tags | cut -f2 -dv)
       - echo "Updating package version to ${PKG_VERSION}"
       - sed --in-place -E "s/__version__ = '.+'/__version__ = '${PKG_VERSION}'/" awsiot/__init__.py


### PR DESCRIPTION
*Description of changes:*

Changes the PyPi release to use a IoT SDK specific token from secrets rather than reusing the CRT one.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
