### PR TITLE
Fix the non-CLI code path for Shadow sample

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -375,7 +375,7 @@ Source: `samples/shadow.py`
 Run the sample like this:
 ``` sh
 # For Windows: replace 'python3' with 'python'
-python3 shadow.py --endpoint <endpoint> --ca_file <file> --cert <file> --key <file> --thing-name <name>
+python3 shadow.py --endpoint <endpoint> --ca_file <file> --cert <file> --key <file> --thing_name <name>
 ```
 
 Your Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html) must provide privileges for this sample to connect, subscribe, publish, and receive. Make sure your policy allows a client ID of `test-*` to connect or use `--client_id <client ID here>` to send the client ID your policy supports.

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -295,8 +295,8 @@ def user_input_thread_fn():
         try:
             messages_sent = 0
             while messages_sent < 5:
-                input = "Shadow_Value_" + str(messages_sent)
-                change_shadow_value(input)
+                cli_input = "Shadow_Value_" + str(messages_sent)
+                change_shadow_value(cli_input)
                 sleep(1)
                 messages_sent += 1
             exit("CI has quit")


### PR DESCRIPTION
*Issue #, if available:*

Fixes #360 

*Description of changes:*

Renames `input` to `cli_input` in the CI part of the Shadow sample so it does not override the `input()` function in the non-CLI part of the Shadow sample. Also fixes the `README` showing the `thing_name` argument as `thing-name`.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
