### PR TITLE
Drop support for Python 3.6 and raise minimum supported version to Py…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ to Python by the `awscrt` package ([PyPI](https://pypi.org/project/awscrt/)) ([G
 ## Installation
 
 ### Minimum Requirements
-* Python 3.6+
+* Python 3.7+
 
 [Step-by-step instructions](./documents/PREREQUISITES.md)
 

--- a/continuous-delivery/publish_to_prod_pypi.yml
+++ b/continuous-delivery/publish_to_prod_pypi.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# this image assumes Ubuntu 14.04 base image
+# this image assumes Ubuntu base image
 phases:
   install:
     commands:

--- a/continuous-delivery/publish_to_test_pypi.yml
+++ b/continuous-delivery/publish_to_test_pypi.yml
@@ -1,5 +1,5 @@
 version: 0.2
-# this image assumes Ubuntu 14.04 base image
+# this image assumes Ubuntu base image
 phases:
   install:
     commands:

--- a/documents/PREREQUISITES.md
+++ b/documents/PREREQUISITES.md
@@ -1,6 +1,6 @@
 # PREREQUISITES
 
-## Python 3.6 of higher
+## Python 3.7 of higher
 
 How you install Python varies from platform to platform. Below are the instructions for Windows, MacOS, and Linux:
 


### PR DESCRIPTION
Python 3.6 went End of Life 10 months ago (end of 2021). Drop support so we can start using sweet 3.7+ features like [dataclasses](https://docs.python.org/3/library/dataclasses.html).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
