### PR TITLE
Update to latest crt lib to add Mac ECC key support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/*
 
 # docs are updated automatically by .github/workflows/docs.yml
 docs/
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.15.2',
+        'awscrt==0.15.3',
     ],
     python_requires='>=3.7',
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update to latest crt-python lib to introduce MacOS ECC key support
- Add .vscode to .gitignore 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
