### PR TITLE
Add proxy support to Greengrass Discovery

### DIFF
--- a/awsiot/greengrass_discovery.py
+++ b/awsiot/greengrass_discovery.py
@@ -19,7 +19,7 @@ class DiscoveryClient:
         tls_context: Client TLS context
         region: AWS region (not used if gg_server_name is set)
         gg_server_name: optional full server name
-        proxy_options (Optional[HttpProxyOptions]): Optional proxy options. If None is provided then a proxy is not used.
+        proxy_options (HttpProxyOptions): Optional proxy options. If None is provided then a proxy is not used.
     """
     __slots__ = [
         '_bootstrap',

--- a/awsiot/greengrass_discovery.py
+++ b/awsiot/greengrass_discovery.py
@@ -19,7 +19,7 @@ class DiscoveryClient:
         tls_context: Client TLS context
         region: AWS region (not used if gg_server_name is set)
         gg_server_name: optional full server name
-        proxy_options (HttpProxyOptions): Optional proxy options. If None is provided then a proxy is not used.
+        proxy_options: Proxy options (if None is provided then a proxy is not used)
     """
     __slots__ = [
         '_bootstrap',
@@ -30,7 +30,7 @@ class DiscoveryClient:
         '_gg_server_name',
         'gg_url',
         'port',
-        "proxy_options"]
+        "_proxy_options"]
 
     def __init__(
             self,

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -45,10 +45,7 @@ tls_context = io.ClientTlsContext(tls_options)
 socket_options = io.SocketOptions()
 
 proxy_options = None
-if cmdUtils.get_command(cmdUtils.m_cmd_proxy_host) != None or cmdUtils.get_command(cmdUtils.m_cmd_proxy_port) != None:
-    if cmdUtils.get_command(cmdUtils.m_cmd_proxy_host) is None and cmdUtils.get_command(cmdUtils.m_cmd_proxy_port) is None:
-        print("Both 'proxy_host' and 'proxy_port' must be set to use a proxy in this sample.")
-        exit(0)
+if cmdUtils.get_command(cmdUtils.m_cmd_proxy_host) != None and cmdUtils.get_command(cmdUtils.m_cmd_proxy_port) != None:
     proxy_options = http.HttpProxyOptions(
         cmdUtils.get_command_required(cmdUtils.m_cmd_proxy_host),
         cmdUtils.get_command_required(cmdUtils.m_cmd_proxy_port))

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -45,10 +45,8 @@ tls_context = io.ClientTlsContext(tls_options)
 socket_options = io.SocketOptions()
 
 proxy_options = None
-if cmdUtils.get_command(cmdUtils.m_cmd_proxy_host) or cmdUtils.get_command(cmdUtils.m_cmd_proxy_port):
-    if cmdUtils.get_command(
-            cmdUtils.m_cmd_proxy_host) is None or cmdUtils.get_command(
-            cmdUtils.m_cmd_proxy_port) is None:
+if cmdUtils.get_command(cmdUtils.m_cmd_proxy_host) != None or cmdUtils.get_command(cmdUtils.m_cmd_proxy_port) != None:
+    if cmdUtils.get_command(cmdUtils.m_cmd_proxy_host) is None and cmdUtils.get_command(cmdUtils.m_cmd_proxy_port) is None:
         print("Both 'proxy_host' and 'proxy_port' must be set to use a proxy in this sample.")
         exit(0)
     proxy_options = http.HttpProxyOptions(


### PR DESCRIPTION
*Issue #, if available:*

#376

*Description of changes:*

Exposes settings needed to allow support for proxy options in the Greengrass discovery client. Also adjusts sample to take proxy host and port settings so it functions the same way as the Java sample.

_____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
