### PR TITLE
CD always get latest version

### DIFF
--- a/utils/publish-release.sh
+++ b/utils/publish-release.sh
@@ -18,7 +18,9 @@ pushd $(dirname $0) > /dev/null
 
 # Get the current version
 git checkout main
-current_version=$(git describe --tags --abbrev=0)
+
+git_tags=$(git tag)
+current_version=$(python3 ./update_semantic_version.py  --version "${git_tags}" --type MINOR --parse_latest_version true)
 current_version_without_v=$(echo ${current_version} | cut -f2 -dv)
 
 echo "Current release version is ${current_version_without_v}"

--- a/utils/update_semantic_version.py
+++ b/utils/update_semantic_version.py
@@ -12,7 +12,45 @@ def main():
                                  required=True, help="The version string to update")
     argument_parser.add_argument("--type", metavar="<string containing PATCH, MINOR, or MAJOR>",
                                  required=True, help="Which version number to bump")
+    argument_parser.add_argument("--parse_latest_version", metavar="<true>",
+        help="Takes '$(git tag)' and returns the highest version in the list", default="false")
     parsed_commands = argument_parser.parse_args()
+
+    if (parsed_commands.parse_latest_version == "true"):
+        version_list = parsed_commands.version.split("\n")
+        highest = [0, 0, 0]
+
+        for i in range(0, len(version_list)):
+            i_version = version_list[i]
+            i_version = i_version.replace("v", "")
+
+            i_version_tuple = i_version.split(".")
+            if (len(i_version_tuple) != 3):
+                continue
+
+            i_version_tuple[0] = int(i_version_tuple[0])
+            i_version_tuple[1] = int(i_version_tuple[1])
+            i_version_tuple[2] = int(i_version_tuple[2])
+
+            if (highest == None):
+                highest = i_version_tuple
+                continue
+            else:
+                if (i_version_tuple[0] > highest[0]):
+                    highest = i_version_tuple
+                    continue
+                if (i_version_tuple[0] >= highest[0] and i_version_tuple[1] > highest[1]):
+                    highest = i_version_tuple
+                    continue
+                if (i_version_tuple[0] >= highest[0] and i_version_tuple[1] >= highest[1] and i_version_tuple[2] >= highest[2]):
+                    highest = i_version_tuple
+                    continue
+
+        if (highest[0] != 0 and highest[1] != 0 and highest[2] != 0):
+            print(f"v{highest[0]}.{highest[1]}.{highest[2]}")
+            sys.exit(0)
+        else:
+            sys.exit(-1)
 
     version_tuple = parsed_commands.version.split(".")
     if len(version_tuple) != 3:


### PR DESCRIPTION
*Description of changes:*

Updates CD to always get the highest git tag version from git tag so even if there are multiple tags on the same day, we always have the newest/latest one.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
