### PR TITLE
Fix TypeError: _check_required_kwargs() in mqtt5_client_builder.new_default_builder

### DIFF
--- a/awsiot/mqtt5_client_builder.py
+++ b/awsiot/mqtt5_client_builder.py
@@ -700,7 +700,7 @@ def new_default_builder(**kwargs) -> awscrt.mqtt5.Client:
     This requires setting the client details manually by passing all the necessary data
     in :mod:`common arguments<awsiot.mqtt5_client_builder>` to make a connection
     """
-    _check_required_kwargs(kwargs)
+    _check_required_kwargs(**kwargs)
     tls_ctx_options = awscrt.io.TlsContextOptions()
     return _builder(tls_ctx_options=tls_ctx_options,
                     use_websockets=False,


### PR DESCRIPTION
*Description of changes:*

Fixed following error in mqtt5_client_builder.new_default_builder

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/dist-packages/awsiot/mqtt5_client_builder.py", line 632, in new_default_builder
    _check_required_kwargs(kwargs)
TypeError: _check_required_kwargs() takes 0 positional arguments but 1 was given
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
