### PR TITLE
custom authorizer: fix incorrect desciption about htttp header in code doc

### DIFF
--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -472,7 +472,7 @@ def direct_with_custom_authorizer(
             If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
 
         auth_authorizer_signature (`str`):  The signature of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
+            If not provided, then "x-amz-customauthorizer-signature" will not be added with the MQTT connection.
 
         auth_password (`str`):  The password to use with the custom authorizer.
             If not provided, then no passord will be set.
@@ -516,7 +516,7 @@ def websockets_with_custom_authorizer(
             If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
 
         auth_authorizer_signature (`str`):  The signature of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
+            If not provided, then "x-amz-customauthorizer-signature" will not be added with the MQTT connection.
 
         auth_password (`str`):  The password to use with the custom authorizer.
             If not provided, then no passord will be set.


### PR DESCRIPTION
Signed-off-by: Alex Li <zhiqinli@amazon.com>

*Issue #, if available:*
If `auth_authorizer_signature` is not provided, `x-amz-customauthorizer-signature` will not be generated in request header.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
