### PR TITLE
Custom auth fixes, tests, and CI framework

### DIFF
--- a/.builder/actions/crt-ci-test.py
+++ b/.builder/actions/crt-ci-test.py
@@ -17,12 +17,8 @@ class CiTest(Builder.Action):
     def run(self, env):
 
         actions = []
-        cert_file_name = None
-        key_file_name = None
 
         try:
-            # Unfortunately, we can't use NamedTemporaryFile and a with-block because NamedTemporaryFile is not readable
-            # on Windows.
             self._write_environment_script_secret_to_env(env, "mqtt5-testing/github-ci-environment")
 
             env.shell.exec(["python3", "-m", "unittest", "discover", "--verbose"], check=True)

--- a/.builder/actions/crt-ci-test.py
+++ b/.builder/actions/crt-ci-test.py
@@ -1,0 +1,33 @@
+import Builder
+import re
+
+class CiTest(Builder.Action):
+
+    def _write_environment_script_secret_to_env(self, env, secret_name):
+        mqtt5_ci_environment_script = env.shell.get_secret(secret_name)
+        env_line = re.compile('^export\s+(\w+)=(.+)')
+
+        lines = mqtt5_ci_environment_script.splitlines()
+        for line in lines:
+            env_pair_match = env_line.match(line)
+            if env_pair_match.group(1) and env_pair_match.group(2):
+                env.shell.setenv(env_pair_match.group(1), env_pair_match.group(2), quiet=True)
+
+
+    def run(self, env):
+
+        actions = []
+        cert_file_name = None
+        key_file_name = None
+
+        try:
+            # Unfortunately, we can't use NamedTemporaryFile and a with-block because NamedTemporaryFile is not readable
+            # on Windows.
+            self._write_environment_script_secret_to_env(env, "mqtt5-testing/github-ci-environment")
+
+            env.shell.exec(["python3", "-m", "unittest", "discover", "--verbose"], check=True)
+        except:
+            print(f'Failure while running tests')
+            actions.append("exit 1")
+
+        return Builder.Script(actions, name='ci-test')

--- a/.builder/actions/crt-ci-test.py
+++ b/.builder/actions/crt-ci-test.py
@@ -19,7 +19,7 @@ class CiTest(Builder.Action):
         actions = []
 
         try:
-            self._write_environment_script_secret_to_env(env, "mqtt5-testing/github-ci-environment")
+            self._write_environment_script_secret_to_env(env, "ci/sdk-unit-testing")
 
             env.shell.exec(["python3", "-m", "unittest", "discover", "--verbose"], check=True)
         except:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ env:
   CI_FLEET_PROVISIONING_ROLE: ${{ secrets.AWS_CI_FLEET_PROVISIONING_ROLE }}
   CI_DEVICE_ADVISOR: ${{ secrets.AWS_CI_DEVICE_ADVISOR_ROLE }}
   CI_MQTT5_ROLE: ${{ secrets.AWS_CI_MQTT5_ROLE }}
-  CI_UNIT_TESTING_REGION: us-east-1
-  CI_UNIT_TESTING_ROLE: arn:aws:iam::180635532705:role/V2_SDK_Unit_Testing
 
 jobs:
   all-python-versions:
@@ -43,8 +41,8 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
-        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
+        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       # There's hackery in builder.json so that when we run on manylinux
       # we build and test using every version of python that we support.
@@ -60,8 +58,8 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
-        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
+        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
       # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
@@ -81,8 +79,8 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
-        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
+        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     # set arm arch
     - name: Install qemu/docker
       run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -103,8 +101,8 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
-        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
+        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
@@ -149,8 +147,8 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
-        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
+        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
@@ -196,8 +194,8 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
-        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
+        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
@@ -247,8 +245,8 @@ jobs:
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
-          aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
+          role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
-    - name: configure AWS credentials (Builder + Unit Tests - CRT)
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        role-to-assume: ${{ env.CI_CRT_BUILDER_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
@@ -181,6 +176,11 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
+    - name: configure AWS credentials (Builder + Unit Tests - CRT)
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ env.CI_CRT_BUILDER_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,10 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
-    - name: configure AWS credentials (Builder + Unit Tests - CRT)
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        role-to-assume: ${{ env.CI_CRT_BUILDER_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ env:
   CI_FLEET_PROVISIONING_ROLE: ${{ secrets.AWS_CI_FLEET_PROVISIONING_ROLE }}
   CI_DEVICE_ADVISOR: ${{ secrets.AWS_CI_DEVICE_ADVISOR_ROLE }}
   CI_MQTT5_ROLE: ${{ secrets.AWS_CI_MQTT5_ROLE }}
+  CI_UNIT_TESTING_REGION: us-east-1
+  CI_UNIT_TESTING_ROLE: arn:aws:iam::180635532705:role/V2_SDK_Unit_Testing
 
 jobs:
   all-python-versions:
@@ -38,15 +40,33 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
+    - name: configure AWS credentials (containers)
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
+        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
       # There's hackery in builder.json so that when we run on manylinux
       # we build and test using every version of python that we support.
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-manylinux2014-x64 build -p ${{ env.PACKAGE_NAME }}
+
+  al2:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for requesting the JWT
+    steps:
+    - name: configure AWS credentials (containers)
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
+        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
+      # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-al2-x64 build -p ${{ env.PACKAGE_NAME }}
 
   raspberry:
     runs-on: ubuntu-latest # latest
@@ -59,10 +79,10 @@ jobs:
           - raspbian-bullseye
     steps:
     - name: configure AWS credentials (containers)
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
+        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
     # set arm arch
     - name: Install qemu/docker
       run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -80,10 +100,12 @@ jobs:
     - name: Install boto3
       run: |
         python -m pip install boto3
+    - name: configure AWS credentials (containers)
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
+        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }}
@@ -124,10 +146,12 @@ jobs:
     - name: Install boto3
       run: |
         python3 -m pip install boto3
+    - name: configure AWS credentials (containers)
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
+        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
@@ -172,12 +196,9 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: arn:aws:iam::180635532705:role/V2_SDK_Unit_Testing
-        aws-region: us-east-1
+        role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
+        aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
-      #env:
-      #  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
-      #  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
@@ -223,10 +244,12 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install softhsm -y
           softhsm2-util --version
+      - name: configure AWS credentials (containers)
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.CI_UNIT_TESTING_ROLE }}
+          aws-region: ${{ env.CI_UNIT_TESTING_REGION }}
       - name: Build ${{ env.PACKAGE_NAME }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,64 +31,9 @@ env:
   CI_FLEET_PROVISIONING_ROLE: ${{ secrets.AWS_CI_FLEET_PROVISIONING_ROLE }}
   CI_DEVICE_ADVISOR: ${{ secrets.AWS_CI_DEVICE_ADVISOR_ROLE }}
   CI_MQTT5_ROLE: ${{ secrets.AWS_CI_MQTT5_ROLE }}
+  CI_BUILD_AND_TEST_ROLE: arn:aws:iam::180635532705:role/V2_SDK_Unit_Testing
 
 jobs:
-  all-python-versions:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # This is required for requesting the JWT
-    steps:
-    - name: configure AWS credentials (containers)
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    - name: Build ${{ env.PACKAGE_NAME }}
-      # There's hackery in builder.json so that when we run on manylinux
-      # we build and test using every version of python that we support.
-      run: |
-        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-manylinux2014-x64 build -p ${{ env.PACKAGE_NAME }}
-
-  al2:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # This is required for requesting the JWT
-    steps:
-    - name: configure AWS credentials (containers)
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
-    - name: Build ${{ env.PACKAGE_NAME }}
-      run: |
-        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-al2-x64 build -p ${{ env.PACKAGE_NAME }}
-
-  raspberry:
-    runs-on: ubuntu-latest # latest
-    permissions:
-      id-token: write # This is required for requesting the JWT
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - raspbian-bullseye
-    steps:
-    - name: configure AWS credentials (containers)
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    # set arm arch
-    - name: Install qemu/docker
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    - name: Build ${{ env.PACKAGE_NAME }}
-      run: |
-        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
-
 
   windows:
     runs-on: windows-latest
@@ -101,7 +46,7 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        role-to-assume: ${{ env.CI_BUILD_AND_TEST_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
@@ -147,7 +92,7 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        role-to-assume: ${{ env.CI_BUILD_AND_TEST_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
@@ -194,7 +139,7 @@ jobs:
     - name: configure AWS credentials (containers)
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+        role-to-assume: ${{ env.CI_BUILD_AND_TEST_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
@@ -245,7 +190,7 @@ jobs:
       - name: configure AWS credentials (containers)
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
+          role-to-assume: ${{ env.CI_BUILD_AND_TEST_ROLE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,10 +169,15 @@ jobs:
     - name: Running samples in CI setup
       run: |
         python -m pip install boto3
+    - name: configure AWS credentials (containers)
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: arn:aws:iam::180635532705:role/V2_SDK_Unit_Testing
+        aws-region: us-east-1
     - name: Build ${{ env.PACKAGE_NAME }}
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
+      #env:
+      #  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
+      #  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,9 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
+    - name: Running samples in CI setup
+      run: |
+        python -m pip install boto3
     - name: Build ${{ env.PACKAGE_NAME }}
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ env:
   CI_UTILS_FOLDER: "./aws-iot-device-sdk-python-v2/utils"
   CI_SAMPLES_CFG_FOLDER: "./aws-iot-device-sdk-python-v2/.github/workflows"
   CI_SAMPLES_FOLDER: "./aws-iot-device-sdk-python-v2/samples"
-  CI_CRT_BUILDER_ROLE: ${{ secrets.AWS_CI_CRT_BUILDER_ROLE }}
   CI_IOT_CONTAINERS_ROLE: ${{ secrets.AWS_CI_IOT_CONTAINERS }}
   CI_PUBSUB_ROLE: ${{ secrets.AWS_CI_PUBSUB_ROLE }}
   CI_COGNITO_ROLE: ${{ secrets.AWS_CI_COGNITO_ROLE }}
@@ -97,6 +96,9 @@ jobs:
       id-token: write # This is required for requesting the JWT
     steps:
     - name: Build ${{ env.PACKAGE_NAME }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }}
@@ -137,7 +139,13 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
+    - name: Install boto3
+      run: |
+        python3 -m pip install boto3
     - name: Build ${{ env.PACKAGE_NAME }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
@@ -222,17 +230,20 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
-      - name: Build ${{ env.PACKAGE_NAME }}
-        run: |
-          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
-          chmod a+x builder
-          ./builder build -p ${{ env.PACKAGE_NAME }}
       - name: Running samples in CI setup
         run: |
           python3 -m pip install boto3
           sudo apt-get update -y
           sudo apt-get install softhsm -y
           softhsm2-util --version
+      - name: Build ${{ env.PACKAGE_NAME }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DA_ROLE_PRIVATE_KEY }}
+        run: |
+          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+          chmod a+x builder
+          ./builder build -p ${{ env.PACKAGE_NAME }}
       - name: configure AWS credentials (Connect and PubSub)
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ env:
   CI_UTILS_FOLDER: "./aws-iot-device-sdk-python-v2/utils"
   CI_SAMPLES_CFG_FOLDER: "./aws-iot-device-sdk-python-v2/.github/workflows"
   CI_SAMPLES_FOLDER: "./aws-iot-device-sdk-python-v2/samples"
-  CI_IOT_CONTAINERS_ROLE: ${{ secrets.AWS_CI_IOT_CONTAINERS }}
   CI_PUBSUB_ROLE: ${{ secrets.AWS_CI_PUBSUB_ROLE }}
   CI_COGNITO_ROLE: ${{ secrets.AWS_CI_COGNITO_ROLE }}
   CI_X509_ROLE: ${{ secrets.AWS_CI_X509_ROLE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,24 +48,6 @@ jobs:
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-manylinux2014-x64 build -p ${{ env.PACKAGE_NAME }}
 
-
-  al2:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # This is required for requesting the JWT
-    steps:
-    - name: configure AWS credentials (containers)
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        role-to-assume: ${{ env.CI_IOT_CONTAINERS_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
-    - name: Build ${{ env.PACKAGE_NAME }}
-      run: |
-        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-al2-x64 build -p ${{ env.PACKAGE_NAME }}
-
-
   raspberry:
     runs-on: ubuntu-latest # latest
     permissions:
@@ -95,6 +77,9 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
+    - name: Install boto3
+      run: |
+        python -m pip install boto3
     - name: Build ${{ env.PACKAGE_NAME }}
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DA_ROLE_KEY }}
@@ -102,9 +87,6 @@ jobs:
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }}
-    - name: Running samples in CI setup
-      run: |
-        python -m pip install boto3
     - name: configure AWS credentials (PubSub)
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ env:
   CI_UTILS_FOLDER: "./aws-iot-device-sdk-python-v2/utils"
   CI_SAMPLES_CFG_FOLDER: "./aws-iot-device-sdk-python-v2/.github/workflows"
   CI_SAMPLES_FOLDER: "./aws-iot-device-sdk-python-v2/samples"
+  CI_CRT_BUILDER_ROLE: ${{ secrets.AWS_CI_CRT_BUILDER_ROLE }}
   CI_IOT_CONTAINERS_ROLE: ${{ secrets.AWS_CI_IOT_CONTAINERS }}
   CI_PUBSUB_ROLE: ${{ secrets.AWS_CI_PUBSUB_ROLE }}
   CI_COGNITO_ROLE: ${{ secrets.AWS_CI_COGNITO_ROLE }}
@@ -95,6 +96,11 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:
+    - name: configure AWS credentials (Builder + Unit Tests - CRT)
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ env.CI_CRT_BUILDER_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"

--- a/awsiot/mqtt5_client_builder.py
+++ b/awsiot/mqtt5_client_builder.py
@@ -627,7 +627,7 @@ def direct_with_custom_authorizer(
             username_string, auth_authorizer_signature, "x-amz-customauthorizer-signature=")
 
     if auth_token_key_name is not None and auth_token_value is not None:
-        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name)
+        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name + "=")
 
     kwargs["username"] = username_string
     kwargs["password"] = auth_password
@@ -646,9 +646,9 @@ def websockets_with_custom_authorizer(
         auth_authorizer_name=None,
         auth_authorizer_signature=None,
         auth_password=None,
+        websocket_proxy_options=None,
         auth_token_key_name=None,
         auth_token_value=None,
-        websocket_proxy_options=None,
         **kwargs) -> awscrt.mqtt5.Client:
     """
     This builder creates an :class:`awscrt.mqtt5.Client`, configured for an MQTT5 Client using a custom

--- a/awsiot/mqtt5_client_builder.py
+++ b/awsiot/mqtt5_client_builder.py
@@ -709,7 +709,7 @@ def websockets_with_custom_authorizer(
             username_string, auth_authorizer_signature, "x-amz-customauthorizer-signature=")
 
     if auth_token_key_name is not None and auth_token_value is not None:
-        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name)
+        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name + "=")
 
     kwargs["username"] = username_string
     kwargs["password"] = auth_password

--- a/awsiot/mqtt5_client_builder.py
+++ b/awsiot/mqtt5_client_builder.py
@@ -569,6 +569,8 @@ def direct_with_custom_authorizer(
         auth_authorizer_name=None,
         auth_authorizer_signature=None,
         auth_password=None,
+        auth_token_key_name=None,
+        auth_token_value=None,
         **kwargs) -> awscrt.mqtt5.Client:
     """
     This builder creates an :class:`awscrt.mqtt5.Client`, configured for an MQTT5 Client using a custom
@@ -581,17 +583,30 @@ def direct_with_custom_authorizer(
         auth_username (`str`): The username to use with the custom authorizer.
             If provided, the username given will be passed when connecting to the custom authorizer.
             If not provided, it will check to see if a username has already been set (via username="example")
-            and will use that instead.
-            If no username has been set then no username will be sent with the MQTT connection.
-
-        auth_authorizer_name (`str`):  The name of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
-
-        auth_authorizer_signature (`str`):  The signature of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
+            and will use that instead.  Custom authentication parameters will be appended as appropriate
+            to any supplied username value.
 
         auth_password (`str`):  The password to use with the custom authorizer.
-            If not provided, then no passord will be set.
+            If not provided, then no password will be sent in the initial CONNECT packet.
+
+        auth_authorizer_name (`str`):  Name of the custom authorizer to use.
+            Required if the endpoint does not have a default custom authorizer associated with it.  It is strongly
+            suggested to URL-encode this value; the SDK will not do so for you.
+
+        auth_authorizer_signature (`str`):  The digital signature of the token value in the `auth_token_value`
+            parameter. The signature must be based on the private key associated with the custom authorizer.  The
+            signature must be base64 encoded.
+            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode this value;
+            the SDK will not do so for you.
+
+        auth_token_key_name (`str`): Key used to extract the custom authorizer token from MQTT username query-string
+            properties.
+            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode
+            this value; the SDK will not do so for you.
+
+        auth_token_value (`str`): An opaque token value. This value must be signed by the private key associated with
+            the custom authorizer and the result passed in via the `auth_authorizer_signature` parameter.
+            Required if the custom authorizer has signing enabled.
     """
 
     _check_required_kwargs(**kwargs)
@@ -606,9 +621,13 @@ def direct_with_custom_authorizer(
     if auth_authorizer_name is not None:
         username_string = _add_to_username_parameter(
             username_string, auth_authorizer_name, "x-amz-customauthorizer-name=")
+
     if auth_authorizer_signature is not None:
         username_string = _add_to_username_parameter(
             username_string, auth_authorizer_signature, "x-amz-customauthorizer-signature=")
+
+    if auth_token_key_name is not None and auth_token_value is not None:
+        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name)
 
     kwargs["username"] = username_string
     kwargs["password"] = auth_password
@@ -627,6 +646,8 @@ def websockets_with_custom_authorizer(
         auth_authorizer_name=None,
         auth_authorizer_signature=None,
         auth_password=None,
+        auth_token_key_name=None,
+        auth_token_value=None,
         websocket_proxy_options=None,
         **kwargs) -> awscrt.mqtt5.Client:
     """
@@ -640,17 +661,30 @@ def websockets_with_custom_authorizer(
         auth_username (`str`): The username to use with the custom authorizer.
             If provided, the username given will be passed when connecting to the custom authorizer.
             If not provided, it will check to see if a username has already been set (via username="example")
-            and will use that instead.
-            If no username has been set then no username will be sent with the MQTT connection.
-
-        auth_authorizer_name (`str`):  The name of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
-
-        auth_authorizer_signature (`str`):  The signature of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
+            and will use that instead.  Custom authentication parameters will be appended as appropriate
+            to any supplied username value.
 
         auth_password (`str`):  The password to use with the custom authorizer.
-            If not provided, then no passord will be set.
+            If not provided, then no password will be sent in the initial CONNECT packet.
+
+        auth_authorizer_name (`str`):  Name of the custom authorizer to use.
+            Required if the endpoint does not have a default custom authorizer associated with it.  It is strongly
+            suggested to URL-encode this value; the SDK will not do so for you.
+
+        auth_authorizer_signature (`str`):  The digital signature of the token value in the `auth_token_value`
+            parameter. The signature must be based on the private key associated with the custom authorizer.  The
+            signature must be base64 encoded.
+            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode this value;
+            the SDK will not do so for you.
+
+        auth_token_key_name (`str`): Key used to extract the custom authorizer token from MQTT username query-string
+            properties.
+            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode
+            this value; the SDK will not do so for you.
+
+        auth_token_value (`str`): An opaque token value. This value must be signed by the private key associated with
+            the custom authorizer and the result passed in via the `auth_authorizer_signature` parameter.
+            Required if the custom authorizer has signing enabled.
 
         websocket_proxy_options (awscrt.http.HttpProxyOptions): Deprecated,
             for proxy settings use `http_proxy_options` (described in
@@ -669,9 +703,13 @@ def websockets_with_custom_authorizer(
     if auth_authorizer_name is not None:
         username_string = _add_to_username_parameter(
             username_string, auth_authorizer_name, "x-amz-customauthorizer-name=")
+
     if auth_authorizer_signature is not None:
         username_string = _add_to_username_parameter(
             username_string, auth_authorizer_signature, "x-amz-customauthorizer-signature=")
+
+    if auth_token_key_name is not None and auth_token_value is not None:
+        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name)
 
     kwargs["username"] = username_string
     kwargs["password"] = auth_password

--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -504,8 +504,8 @@ def direct_with_custom_authorizer(
         **kwargs)
 
 def websockets_with_custom_authorizer(
-        region,
-        credentials_provider,
+        region=None,
+        credentials_provider=None,
         auth_username=None,
         auth_authorizer_name=None,
         auth_authorizer_signature=None,
@@ -612,17 +612,7 @@ def _with_custom_authorizer(auth_username=None,
     def _sign_websocket_handshake_request(transform_args, **kwargs):
         # transform_args need to know when transform is done
         try:
-            signing_config = awscrt.auth.AwsSigningConfig(
-                algorithm=awscrt.auth.AwsSigningAlgorithm.V4,
-                signature_type=awscrt.auth.AwsSignatureType.HTTP_REQUEST_QUERY_PARAMS,
-                credentials_provider=websockets_credentials_provider,
-                region=websockets_region,
-                service='iotdevicegateway',
-                omit_session_token=True,  # IoT is weird and does not sign X-Amz-Security-Token
-            )
-
-            signing_future = awscrt.auth.aws_sign_request(transform_args.http_request, signing_config)
-            signing_future.add_done_callback(lambda x: transform_args.set_done(x.exception()))
+            transform_args.set_done()
         except Exception as e:
             transform_args.set_done(e)
 

--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -453,6 +453,8 @@ def direct_with_custom_authorizer(
         auth_authorizer_name=None,
         auth_authorizer_signature=None,
         auth_password=None,
+        auth_token_key_name=None,
+        auth_token_value=None,
         **kwargs) -> awscrt.mqtt.Connection:
     """
     This builder creates an :class:`awscrt.mqtt.Connection`, configured for an MQTT connection using a custom
@@ -465,17 +467,30 @@ def direct_with_custom_authorizer(
         auth_username (`str`): The username to use with the custom authorizer.
             If provided, the username given will be passed when connecting to the custom authorizer.
             If not provided, it will check to see if a username has already been set (via username="example")
-            and will use that instead.
-            If no username has been set then no username will be sent with the MQTT connection.
-
-        auth_authorizer_name (`str`):  The name of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
-
-        auth_authorizer_signature (`str`):  The signature of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
+            and will use that instead.  Custom authentication parameters will be appended as appropriate
+            to any supplied username value.
 
         auth_password (`str`):  The password to use with the custom authorizer.
-            If not provided, then no passord will be set.
+            If not provided, then no password will be sent in the initial CONNECT packet.
+
+        auth_authorizer_name (`str`):  Name of the custom authorizer to use.
+            Required if the endpoint does not have a default custom authorizer associated with it.  It is strongly
+            suggested to URL-encode this value; the SDK will not do so for you.
+
+        auth_authorizer_signature (`str`):  The digital signature of the token value in the `auth_token_value`
+            parameter. The signature must be based on the private key associated with the custom authorizer.  The
+            signature must be base64 encoded.
+            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode this value;
+            the SDK will not do so for you.
+
+        auth_token_key_name (`str`): Key used to extract the custom authorizer token from MQTT username query-string
+            properties.
+            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode
+            this value; the SDK will not do so for you.
+
+        auth_token_value (`str`): An opaque token value. This value must be signed by the private key associated with
+            the custom authorizer and the result passed in via the `auth_authorizer_signature` parameter.
+            Required if the custom authorizer has signing enabled.
     """
 
     return _with_custom_authorizer(
@@ -483,6 +498,8 @@ def direct_with_custom_authorizer(
         auth_authorizer_name=auth_authorizer_name,
         auth_authorizer_signature=auth_authorizer_signature,
         auth_password=auth_password,
+        auth_token_key_name=auth_token_key_name,
+        auth_token_value=auth_token_value,
         use_websockets=False,
         **kwargs)
 
@@ -493,6 +510,8 @@ def websockets_with_custom_authorizer(
         auth_authorizer_name=None,
         auth_authorizer_signature=None,
         auth_password=None,
+        auth_token_key_name=None,
+        auth_token_value=None,
         **kwargs) -> awscrt.mqtt.Connection:
     """
     This builder creates an :class:`awscrt.mqtt.Connection`, configured for an MQTT connection using a custom
@@ -509,17 +528,30 @@ def websockets_with_custom_authorizer(
         auth_username (`str`): The username to use with the custom authorizer.
             If provided, the username given will be passed when connecting to the custom authorizer.
             If not provided, it will check to see if a username has already been set (via username="example")
-            and will use that instead.
-            If no username has been set then no username will be sent with the MQTT connection.
-
-        auth_authorizer_name (`str`):  The name of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
-
-        auth_authorizer_signature (`str`):  The signature of the custom authorizer.
-            If not provided, then "x-amz-customauthorizer-name" will not be added with the MQTT connection.
+            and will use that instead.  Custom authentication parameters will be appended as appropriate
+            to any supplied username value.
 
         auth_password (`str`):  The password to use with the custom authorizer.
-            If not provided, then no passord will be set.
+            If not provided, then no password will be sent in the initial CONNECT packet.
+
+        auth_authorizer_name (`str`):  Name of the custom authorizer to use.
+            Required if the endpoint does not have a default custom authorizer associated with it.  It is strongly
+            suggested to URL-encode this value; the SDK will not do so for you.
+
+        auth_authorizer_signature (`str`):  The digital signature of the token value in the `auth_token_value`
+            parameter. The signature must be based on the private key associated with the custom authorizer.  The
+            signature must be base64 encoded.
+            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode this value;
+            the SDK will not do so for you.
+
+        auth_token_key_name (`str`): Key used to extract the custom authorizer token from MQTT username query-string
+            properties.
+            Required if the custom authorizer has signing enabled.  It is strongly suggested to URL-encode
+            this value; the SDK will not do so for you.
+
+        auth_token_value (`str`): An opaque token value. This value must be signed by the private key associated with
+            the custom authorizer and the result passed in via the `auth_authorizer_signature` parameter.
+            Required if the custom authorizer has signing enabled.
     """
 
     return _with_custom_authorizer(
@@ -527,6 +559,8 @@ def websockets_with_custom_authorizer(
         auth_authorizer_name=auth_authorizer_name,
         auth_authorizer_signature=auth_authorizer_signature,
         auth_password=auth_password,
+        auth_token_key_name=auth_token_key_name,
+        auth_token_value=auth_token_value,
         use_websockets=True,
         websockets_region=region,
         websockets_credentials_provider=credentials_provider,
@@ -537,6 +571,8 @@ def _with_custom_authorizer(auth_username=None,
         auth_authorizer_name=None,
         auth_authorizer_signature=None,
         auth_password=None,
+        auth_token_key_name=None,
+        auth_token_value=None,
         use_websockets=False,
         websockets_credentials_provider=None,
         websockets_region=None,
@@ -557,9 +593,13 @@ def _with_custom_authorizer(auth_username=None,
     if auth_authorizer_name is not None:
         username_string = _add_to_username_parameter(
             username_string, auth_authorizer_name, "x-amz-customauthorizer-name=")
+
     if auth_authorizer_signature is not None:
         username_string = _add_to_username_parameter(
             username_string, auth_authorizer_signature, "x-amz-customauthorizer-signature=")
+
+    if auth_token_key_name is not None and auth_token_value is not None:
+        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name)
 
     kwargs["username"] = username_string
     kwargs["password"] = auth_password

--- a/awsiot/mqtt_connection_builder.py
+++ b/awsiot/mqtt_connection_builder.py
@@ -599,7 +599,7 @@ def _with_custom_authorizer(auth_username=None,
             username_string, auth_authorizer_signature, "x-amz-customauthorizer-signature=")
 
     if auth_token_key_name is not None and auth_token_value is not None:
-        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name)
+        username_string = _add_to_username_parameter(username_string, auth_token_value, auth_token_key_name + "=")
 
     kwargs["username"] = username_string
     kwargs["password"] = auth_password

--- a/builder.json
+++ b/builder.json
@@ -88,7 +88,7 @@
         ["{python}", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
         ["{python}", "-m", "pip", "install", ".", "--verbose"],
         ["{python}", "-m", "pip", "install", "boto3", "autopep8"],
-        ["{python}", "-m", "unittest", "discover", "--verbose"]
+        "ci-test"
     ],
     "build_steps": [
         "python3 -m pip install ."

--- a/builder.json
+++ b/builder.json
@@ -84,16 +84,12 @@
     "build": [
         ["{python}", "-c", "print('ignore this fake build step')"]
     ],
-    "test": [
-        ["{python}", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
-        ["{python}", "-m", "pip", "install", ".", "--verbose"],
-        ["{python}", "-m", "pip", "install", "boto3", "autopep8"],
-        "ci-test"
-    ],
     "build_steps": [
         "python3 -m pip install ."
     ],
     "test_steps": [
+        ["python3", "-m", "pip", "install", "boto3", "autopep8"],
+        "ci-test"
     ],
     "env": {
     }

--- a/builder.json
+++ b/builder.json
@@ -88,7 +88,6 @@
         "python3 -m pip install ."
     ],
     "test_steps": [
-        ["python3", "-m", "pip", "install", "boto3", "autopep8"],
         "ci-test"
     ],
     "env": {

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -175,7 +175,7 @@ class MqttBuilderTest(unittest.TestCase):
         self._test_connection(connection)
 
     @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
-    def test_mqtt311_builder_signed_custom_authorizer_direct(self):
+    def test_mqtt311_builder_direct_signed_custom_authorizer(self):
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
@@ -194,7 +194,7 @@ class MqttBuilderTest(unittest.TestCase):
         self._test_connection(connection)
 
     @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
-    def test_mqtt311_builder_unsigned_custom_authorizer_direct(self):
+    def test_mqtt311_builder_direct_unsigned_custom_authorizer(self):
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
@@ -211,3 +211,39 @@ class MqttBuilderTest(unittest.TestCase):
             client_bootstrap=bootstrap)
 
         self._test_connection(connection)
+
+    @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
+    def test_mqtt311_builder_websocket_unsigned_custom_authorizer(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+
+        connection = mqtt_connection_builder.websockets_with_custom_authorizer(
+            auth_username="",
+            auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_UNSIGNED,
+            auth_password=CUSTOM_AUTHORIZER_PASSWORD,
+            endpoint=CUSTOM_AUTHORIZER_ENDPOINT,
+            client_id=create_client_id(),
+            client_bootstrap=bootstrap)
+
+        self._test_connection(connection)
+
+    @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
+    def test_mqtt311_builder_websocket_signed_custom_authorizer(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+
+        connection = mqtt_connection_builder.websockets_with_custom_authorizer(
+            auth_username="",
+            auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_SIGNED,
+            auth_authorizer_signature=CUSTOM_AUTHORIZER_SIGNATURE,
+            auth_password=CUSTOM_AUTHORIZER_PASSWORD,
+            auth_token_key_name=CUSTOM_AUTHORIZER_TOKEN_KEY_NAME,
+            auth_token_value=CUSTOM_AUTHORIZER_TOKEN_VALUE,
+            endpoint=CUSTOM_AUTHORIZER_ENDPOINT,
+            client_id=create_client_id(),
+            client_bootstrap=bootstrap)
+
+        self._test_connection(connection)
+

--- a/test/test_mqtt.py
+++ b/test/test_mqtt.py
@@ -14,6 +14,20 @@ TIMEOUT = 100.0
 PROXY_HOST = os.environ.get('proxyhost')
 PROXY_PORT = int(os.environ.get('proxyport', '0'))
 
+CUSTOM_AUTHORIZER_ENDPOINT = os.environ.get("CUSTOM_AUTHORIZER_ENDPOINT")
+CUSTOM_AUTHORIZER_NAME_SIGNED = os.environ.get("CUSTOM_AUTHORIZER_NAME_SIGNED")
+CUSTOM_AUTHORIZER_NAME_UNSIGNED = os.environ.get("CUSTOM_AUTHORIZER_NAME_UNSIGNED")
+CUSTOM_AUTHORIZER_PASSWORD = os.environ.get("CUSTOM_AUTHORIZER_PASSWORD")
+CUSTOM_AUTHORIZER_SIGNATURE = os.environ.get("CUSTOM_AUTHORIZER_SIGNATURE")
+CUSTOM_AUTHORIZER_TOKEN_KEY_NAME = os.environ.get("CUSTOM_AUTHORIZER_TOKEN_KEY_NAME")
+CUSTOM_AUTHORIZER_TOKEN_VALUE = os.environ.get("CUSTOM_AUTHORIZER_TOKEN_VALUE")
+
+
+def has_custom_auth_environment():
+    return (CUSTOM_AUTHORIZER_ENDPOINT is not None) and (CUSTOM_AUTHORIZER_NAME_SIGNED is not None) and \
+           (CUSTOM_AUTHORIZER_NAME_UNSIGNED is not None) and (CUSTOM_AUTHORIZER_PASSWORD is not None) and \
+           (CUSTOM_AUTHORIZER_SIGNATURE is not None) and (CUSTOM_AUTHORIZER_TOKEN_KEY_NAME is not None) and \
+           (CUSTOM_AUTHORIZER_TOKEN_VALUE is not None)
 
 class Config:
     cache = None
@@ -158,4 +172,42 @@ class MqttBuilderTest(unittest.TestCase):
             region=config.region,
             client_id=create_client_id(),
             client_bootstrap=bootstrap)
+        self._test_connection(connection)
+
+    @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
+    def test_mqtt311_builder_signed_custom_authorizer_direct(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+
+        connection = mqtt_connection_builder.direct_with_custom_authorizer(
+            auth_username="",
+            auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_SIGNED,
+            auth_authorizer_signature=CUSTOM_AUTHORIZER_SIGNATURE,
+            auth_password=CUSTOM_AUTHORIZER_PASSWORD,
+            auth_token_key_name=CUSTOM_AUTHORIZER_TOKEN_KEY_NAME,
+            auth_token_value=CUSTOM_AUTHORIZER_TOKEN_VALUE,
+            endpoint=CUSTOM_AUTHORIZER_ENDPOINT,
+            client_id=create_client_id(),
+            client_bootstrap=bootstrap)
+
+        self._test_connection(connection)
+
+    @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
+    def test_mqtt311_builder_unsigned_custom_authorizer_direct(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+
+        connection = mqtt_connection_builder.direct_with_custom_authorizer(
+            auth_username="",
+            auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_SIGNED,
+            auth_authorizer_signature=CUSTOM_AUTHORIZER_SIGNATURE,
+            auth_password=CUSTOM_AUTHORIZER_PASSWORD,
+            auth_token_key_name=CUSTOM_AUTHORIZER_TOKEN_KEY_NAME,
+            auth_token_value=CUSTOM_AUTHORIZER_TOKEN_VALUE,
+            endpoint=CUSTOM_AUTHORIZER_ENDPOINT,
+            client_id=create_client_id(),
+            client_bootstrap=bootstrap)
+
         self._test_connection(connection)

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -215,7 +215,7 @@ class Mqtt5BuilderTest(unittest.TestCase):
         self._test_connection(client, callbacks)
 
     @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
-    def test_mqtt5_direct_signed_custom_authorizer(self):
+    def test_mqtt5_builder_direct_signed_custom_authorizer(self):
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
@@ -237,13 +237,54 @@ class Mqtt5BuilderTest(unittest.TestCase):
         self._test_connection(client, callbacks)
 
     @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
-    def test_mqtt5_direct_unsigned_custom_authorizer(self):
+    def test_mqtt5_builder_direct_unsigned_custom_authorizer(self):
         elg = EventLoopGroup()
         resolver = DefaultHostResolver(elg)
         bootstrap = ClientBootstrap(elg, resolver)
         callbacks = Mqtt5TestCallbacks()
 
         client = mqtt5_client_builder.direct_with_custom_authorizer(
+            auth_username="",
+            auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_UNSIGNED,
+            auth_password=CUSTOM_AUTHORIZER_PASSWORD,
+            endpoint=CUSTOM_AUTHORIZER_ENDPOINT,
+            client_id=create_client_id(),
+            client_bootstrap=bootstrap,
+            on_lifecycle_connection_success=callbacks.on_lifecycle_connection_success,
+            on_lifecycle_stopped=callbacks.on_lifecycle_stopped)
+
+        self._test_connection(client, callbacks)
+
+    @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
+    def test_mqtt5_builder_websocket_signed_custom_authorizer(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        callbacks = Mqtt5TestCallbacks()
+
+        client = mqtt5_client_builder.websockets_with_custom_authorizer(
+            auth_username="",
+            auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_SIGNED,
+            auth_authorizer_signature=CUSTOM_AUTHORIZER_SIGNATURE,
+            auth_password=CUSTOM_AUTHORIZER_PASSWORD,
+            auth_token_key_name=CUSTOM_AUTHORIZER_TOKEN_KEY_NAME,
+            auth_token_value=CUSTOM_AUTHORIZER_TOKEN_VALUE,
+            endpoint=CUSTOM_AUTHORIZER_ENDPOINT,
+            client_id=create_client_id(),
+            client_bootstrap=bootstrap,
+            on_lifecycle_connection_success=callbacks.on_lifecycle_connection_success,
+            on_lifecycle_stopped=callbacks.on_lifecycle_stopped)
+
+        self._test_connection(client, callbacks)
+
+    @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
+    def test_mqtt5_builder_websocket_unsigned_custom_authorizer(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        callbacks = Mqtt5TestCallbacks()
+
+        client = mqtt5_client_builder.websockets_with_custom_authorizer(
             auth_username="",
             auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_UNSIGNED,
             auth_password=CUSTOM_AUTHORIZER_PASSWORD,

--- a/test/test_mqtt5.py
+++ b/test/test_mqtt5.py
@@ -16,6 +16,20 @@ TIMEOUT = 100.0
 PROXY_HOST = os.environ.get('proxyhost')
 PROXY_PORT = int(os.environ.get('proxyport', '0'))
 
+CUSTOM_AUTHORIZER_ENDPOINT = os.environ.get("CUSTOM_AUTHORIZER_ENDPOINT")
+CUSTOM_AUTHORIZER_NAME_SIGNED = os.environ.get("CUSTOM_AUTHORIZER_NAME_SIGNED")
+CUSTOM_AUTHORIZER_NAME_UNSIGNED = os.environ.get("CUSTOM_AUTHORIZER_NAME_UNSIGNED")
+CUSTOM_AUTHORIZER_PASSWORD = os.environ.get("CUSTOM_AUTHORIZER_PASSWORD")
+CUSTOM_AUTHORIZER_SIGNATURE = os.environ.get("CUSTOM_AUTHORIZER_SIGNATURE")
+CUSTOM_AUTHORIZER_TOKEN_KEY_NAME = os.environ.get("CUSTOM_AUTHORIZER_TOKEN_KEY_NAME")
+CUSTOM_AUTHORIZER_TOKEN_VALUE = os.environ.get("CUSTOM_AUTHORIZER_TOKEN_VALUE")
+
+
+def has_custom_auth_environment():
+    return (CUSTOM_AUTHORIZER_ENDPOINT is not None) and (CUSTOM_AUTHORIZER_NAME_SIGNED is not None) and \
+           (CUSTOM_AUTHORIZER_NAME_UNSIGNED is not None) and (CUSTOM_AUTHORIZER_PASSWORD is not None) and \
+           (CUSTOM_AUTHORIZER_SIGNATURE is not None) and (CUSTOM_AUTHORIZER_TOKEN_KEY_NAME is not None) and \
+           (CUSTOM_AUTHORIZER_TOKEN_VALUE is not None)
 
 class Config:
     cache = None
@@ -193,6 +207,47 @@ class Mqtt5BuilderTest(unittest.TestCase):
             credentials_provider=cred_provider,
             endpoint=config.endpoint,
             websocket_proxy_options=http.HttpProxyOptions(PROXY_HOST, PROXY_PORT),
+            client_id=create_client_id(),
+            client_bootstrap=bootstrap,
+            on_lifecycle_connection_success=callbacks.on_lifecycle_connection_success,
+            on_lifecycle_stopped=callbacks.on_lifecycle_stopped)
+
+        self._test_connection(client, callbacks)
+
+    @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
+    def test_mqtt5_direct_signed_custom_authorizer(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        callbacks = Mqtt5TestCallbacks()
+
+        client = mqtt5_client_builder.direct_with_custom_authorizer(
+            auth_username="",
+            auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_SIGNED,
+            auth_authorizer_signature=CUSTOM_AUTHORIZER_SIGNATURE,
+            auth_password=CUSTOM_AUTHORIZER_PASSWORD,
+            auth_token_key_name=CUSTOM_AUTHORIZER_TOKEN_KEY_NAME,
+            auth_token_value=CUSTOM_AUTHORIZER_TOKEN_VALUE,
+            endpoint=CUSTOM_AUTHORIZER_ENDPOINT,
+            client_id=create_client_id(),
+            client_bootstrap=bootstrap,
+            on_lifecycle_connection_success=callbacks.on_lifecycle_connection_success,
+            on_lifecycle_stopped=callbacks.on_lifecycle_stopped)
+
+        self._test_connection(client, callbacks)
+
+    @unittest.skipIf(not has_custom_auth_environment(), 'requires custom authentication env vars')
+    def test_mqtt5_direct_unsigned_custom_authorizer(self):
+        elg = EventLoopGroup()
+        resolver = DefaultHostResolver(elg)
+        bootstrap = ClientBootstrap(elg, resolver)
+        callbacks = Mqtt5TestCallbacks()
+
+        client = mqtt5_client_builder.direct_with_custom_authorizer(
+            auth_username="",
+            auth_authorizer_name=CUSTOM_AUTHORIZER_NAME_UNSIGNED,
+            auth_password=CUSTOM_AUTHORIZER_PASSWORD,
+            endpoint=CUSTOM_AUTHORIZER_ENDPOINT,
             client_id=create_client_id(),
             client_bootstrap=bootstrap,
             on_lifecycle_connection_success=callbacks.on_lifecycle_connection_success,


### PR DESCRIPTION
* Remove CI jobs that used CRT containers.  We should not use CRT credentials in any way in SDK repos.
* A variety of custom auth bug fixes, primarily around websockets and mqtt311
* Adds full support for signed custom authorizers to both mqtt5 and mqtt311 builders
* Restores unit tests runs when built with aws-crt-builder
* Adds matrix of custom auth tests for both mqtt311 and mqtt5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
