### PR TITLE
Fix information in sample README

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -21,7 +21,7 @@
 
 First, install the `aws-iot-devices-sdk-python-v2` with following the instructions from [Installation](../README.md#Installation).
 
-Then change into the `samples` folder/directory to run the Python commands to execute the samples. Each sample README has instructions on how to run each sample and each sample can be run from the `samples` folder. For example, to run the [PubSub](./pubsub/README.md) sample:
+Each sample README has instructions on how to run each sample with the same name as the sample itself. For example, the [PubSub README](./pubsub.md) is `pubsub.md` and it can be run with the following:
 
 ``` sh
 # For Windows: replace 'python3' with 'python' and '/' with '\'


### PR DESCRIPTION
*Description of changes:*

When the sample README split was done, it initially was planned to be in sub-folders and the main sample README referred to this. However, after discussion, the decided plan was to have all the samples in the same folder like before but with README files of the same name as the same (example: `pubsub.py` and `pubsub.md`), but the earlier adjustment to the main sample README still referred to the sub-folder solution.

This PR fixes that reference and makes it correct.
Resolves the discussion here: https://github.com/aws/aws-iot-device-sdk-python-v2/discussions/423

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
