### PR TITLE
Update authorizer_signature to use the right cmd name

### DIFF
--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -135,7 +135,7 @@ class CommandLineUtils:
             "<str>",
             "The name of the custom authorizer to connect to (optional but required for everything but custom domains)")
         self.register_command(
-            self.m_cmd_custom_auth_username,
+            self.m_cmd_custom_auth_authorizer_signature,
             "<str>",
             "The signature to send when connecting through a custom authorizer (optional)")
         self.register_command(


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Was using `username`. Changing to use `authorizer_signature`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
