### PR TITLE
Sample and command line refactor

### DIFF
--- a/.github/workflows/ci_run_custom_authorizer_connect_cfg.json
+++ b/.github/workflows/ci_run_custom_authorizer_connect_cfg.json
@@ -9,6 +9,10 @@
             "secret": "ci/endpoint"
         },
         {
+            "name": "--signing_region",
+            "data": "us-east-1"
+        },
+        {
             "name": "--custom_auth_authorizer_name",
             "secret": "ci/CustomAuthorizer/name"
         },

--- a/.github/workflows/ci_run_mqtt5_custom_authorizer_cfg.json
+++ b/.github/workflows/ci_run_mqtt5_custom_authorizer_cfg.json
@@ -15,6 +15,16 @@
         {
             "name": "--custom_auth_password",
             "secret": "ci/CustomAuthorizer/password"
+        },
+        {
+            "name": "--cert",
+            "secret": "ci/PubSub/cert",
+            "filename": "tmp_certificate.pem"
+        },
+        {
+            "name": "--key",
+            "secret": "ci/PubSub/key",
+            "filename": "tmp_key.pem"
         }
     ]
 }

--- a/.github/workflows/ci_run_mqtt5_custom_authorizer_cfg.json
+++ b/.github/workflows/ci_run_mqtt5_custom_authorizer_cfg.json
@@ -18,12 +18,12 @@
         },
         {
             "name": "--cert",
-            "secret": "ci/PubSub/cert",
+            "secret": "ci/mqtt5/us/mqtt5_thing/cert",
             "filename": "tmp_certificate.pem"
         },
         {
             "name": "--key",
-            "secret": "ci/PubSub/key",
+            "secret": "ci/mqtt5/us/mqtt5_thing/key",
             "filename": "tmp_key.pem"
         }
     ]

--- a/.github/workflows/ci_run_mqtt5_custom_authorizer_websockets_cfg.json
+++ b/.github/workflows/ci_run_mqtt5_custom_authorizer_websockets_cfg.json
@@ -19,6 +19,10 @@
         {
             "name": "--use_websockets",
             "data": "true"
+        },
+        {
+            "name": "--signing_region",
+            "data": "us-east-1"
         }
     ]
 }

--- a/.github/workflows/ci_run_mqtt5_pubsub_cfg.json
+++ b/.github/workflows/ci_run_mqtt5_pubsub_cfg.json
@@ -17,6 +17,10 @@
             "name": "--key",
             "secret": "ci/mqtt5/us/mqtt5_thing/key",
             "filename": "tmp_key.pem"
+        },
+        {
+            "name": "--is_ci",
+            "data": "true"
         }
     ]
 }

--- a/.github/workflows/ci_run_mqtt5_shared_subscription_cfg.json
+++ b/.github/workflows/ci_run_mqtt5_shared_subscription_cfg.json
@@ -17,6 +17,10 @@
             "name": "--key",
             "secret": "ci/mqtt5/us/mqtt5_thing/key",
             "filename": "tmp_key.pem"
+        },
+        {
+            "name": "--is_ci",
+            "data": "true"
         }
     ]
 }

--- a/.github/workflows/ci_run_pubsub_cfg.json
+++ b/.github/workflows/ci_run_pubsub_cfg.json
@@ -17,6 +17,10 @@
             "name": "--key",
             "secret": "ci/PubSub/key",
             "filename": "tmp_key.pem"
+        },
+        {
+            "name": "--is_ci",
+            "data": "true"
         }
     ]
 }

--- a/codebuild/samples/custom-auth-linux.sh
+++ b/codebuild/samples/custom-auth-linux.sh
@@ -12,6 +12,6 @@ AUTH_NAME=$(aws secretsmanager get-secret-value --secret-id "ci/CustomAuthorizer
 AUTH_PASSWORD=$(aws secretsmanager get-secret-value --secret-id "ci/CustomAuthorizer/password" --query "SecretString" | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
 
 echo "Custom Authorizer test"
-python3 custom_authorizer_connect.py --endpoint $ENDPOINT --custom_auth_authorizer_name $AUTH_NAME --custom_auth_password $AUTH_PASSWORD
+python3 custom_authorizer_connect.py --endpoint $ENDPOINT --custom_auth_authorizer_name $AUTH_NAME --custom_auth_password $AUTH_PASSWORD --signing_region us-east-1
 
 popd

--- a/codebuild/samples/pubsub-linux.sh
+++ b/codebuild/samples/pubsub-linux.sh
@@ -10,6 +10,6 @@ pushd $CODEBUILD_SRC_DIR/samples/
 ENDPOINT=$(aws secretsmanager get-secret-value --secret-id "ci/endpoint" --query "SecretString" | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
 
 echo "PubSub test"
-python3 pubsub.py --endpoint $ENDPOINT --key /tmp/privatekey.pem --cert /tmp/certificate.pem
+python3 pubsub.py --endpoint $ENDPOINT --key /tmp/privatekey.pem --cert /tmp/certificate.pem --is_ci "true"
 
 popd

--- a/codebuild/samples/pubsub-mqtt5-linux.sh
+++ b/codebuild/samples/pubsub-mqtt5-linux.sh
@@ -10,6 +10,6 @@ pushd $CODEBUILD_SRC_DIR/samples/
 ENDPOINT=$(aws secretsmanager get-secret-value --secret-id "ci/endpoint" --query "SecretString" | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
 
 echo "MQTT5 PubSub test"
-python3 mqtt5_pubsub.py --endpoint $ENDPOINT --key /tmp/privatekey.pem --cert /tmp/certificate.pem
+python3 mqtt5_pubsub.py --endpoint $ENDPOINT --key /tmp/privatekey.pem --cert /tmp/certificate.pem --is_ci "true"
 
 popd

--- a/samples/basic_connect.py
+++ b/samples/basic_connect.py
@@ -5,28 +5,10 @@ from awscrt import http
 from awsiot import mqtt_connection_builder
 from uuid import uuid4
 
+from utils.command_line_utils import CommandLineUtils
+
 # This sample shows how to create a MQTT connection using a certificate file and key file.
 # This sample is intended to be used as a reference for making MQTT connections.
-
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("Basic Connect - Make a MQTT connection.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_proxy_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("key", "<path>", "Path to your key in PEM format.", True, str)
-cmdUtils.register_command("cert", "<path>", "Path to your client certificate in PEM format.", True, str)
-cmdUtils.register_command("port", "<int>",
-                          "Connection port for direct connection. " +
-                          "AWS IoT supports 443 and 8883 (optional, default=8883).",
-                          False, int)
-cmdUtils.register_command("client_id", "<str>",
-                          "Client ID to use for MQTT connection (optional, default='test-*').",
-                          default="test-" + str(uuid4()))
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
-is_ci = cmdUtils.get_command("is_ci", None) is not None
 
 # Callback when connection is accidentally lost.
 def on_connection_interrupted(connection, error, **kwargs):
@@ -42,7 +24,7 @@ if __name__ == '__main__':
     # cmdData is the arguments/input from the command line placed into a single struct for
     # use in this sample. This handles all of the command line parsing, validating, etc.
     # See the Utils/CommandLineUtils for more information.
-    cmdData = cmdUtils.parse_sample_input_basic_connect()
+    cmdData = CommandLineUtils.parse_sample_input_basic_connect()
 
     # Create the proxy options if the data is present in cmdData
     proxy_options = None

--- a/samples/basic_connect.py
+++ b/samples/basic_connect.py
@@ -3,7 +3,6 @@
 
 from awscrt import http
 from awsiot import mqtt_connection_builder
-from uuid import uuid4
 
 from utils.command_line_utils import CommandLineUtils
 

--- a/samples/basic_connect.py
+++ b/samples/basic_connect.py
@@ -3,7 +3,6 @@
 
 from awscrt import http
 from awsiot import mqtt_connection_builder
-
 from utils.command_line_utils import CommandLineUtils
 
 # This sample shows how to create a MQTT connection using a certificate file and key file.

--- a/samples/basic_connect.py
+++ b/samples/basic_connect.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
+from awscrt import http
+from awsiot import mqtt_connection_builder
 from uuid import uuid4
 
 # This sample shows how to create a MQTT connection using a certificate file and key file.
@@ -24,7 +26,7 @@ cmdUtils.register_command("client_id", "<str>",
 cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
 # Needs to be called so the command utils parse the commands
 cmdUtils.get_args()
-is_ci = cmdUtils.get_command("is_ci", None) != None
+is_ci = cmdUtils.get_command("is_ci", None) is not None
 
 # Callback when connection is accidentally lost.
 def on_connection_interrupted(connection, error, **kwargs):
@@ -36,19 +38,40 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 
 
 if __name__ == '__main__':
-    # Create a connection using a certificate and key.
-    # Note: The data for the connection is gotten from cmdUtils.
-    # (see build_direct_mqtt_connection for implementation)
-    mqtt_connection = cmdUtils.build_direct_mqtt_connection(on_connection_interrupted, on_connection_resumed)
 
-    if is_ci == False:
+    # cmdData is the arguments/input from the command line placed into a single struct for
+    # use in this sample. This handles all of the command line parsing, validating, etc.
+    # See the Utils/CommandLineUtils for more information.
+    cmdData = cmdUtils.parse_sample_input_basic_connect()
+
+    # Create the proxy options if the data is present in cmdData
+    proxy_options = None
+    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+        proxy_options = http.HttpProxyOptions(
+            host_name=cmdData.input_proxyHost,
+            port=cmdData.input_proxyPort)
+
+    # Create a MQTT connection from the command line data
+    mqtt_connection = mqtt_connection_builder.mtls_from_path(
+        endpoint=cmdData.input_endpoint,
+        port=cmdData.input_port,
+        cert_filepath=cmdData.input_cert,
+        pri_key_filepath=cmdData.input_key,
+        ca_filepath=cmdData.input_ca,
+        on_connection_interrupted=on_connection_interrupted,
+        on_connection_resumed=on_connection_resumed,
+        client_id=cmdData.input_clientId,
+        clean_session=False,
+        keep_alive_secs=30,
+        http_proxy_options=proxy_options)
+
+    if not cmdData.input_isCI:
         print("Connecting to {} with client ID '{}'...".format(
             cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
     else:
         print("Connecting to endpoint with client ID")
 
     connect_future = mqtt_connection.connect()
-
     # Future.result() waits until a result is available
     connect_future.result()
     print("Connected!")

--- a/samples/basic_connect.py
+++ b/samples/basic_connect.py
@@ -26,10 +26,10 @@ if __name__ == '__main__':
 
     # Create the proxy options if the data is present in cmdData
     proxy_options = None
-    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+    if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=cmdData.input_proxyHost,
-            port=cmdData.input_proxyPort)
+            host_name=cmdData.input_proxy_host,
+            port=cmdData.input_proxy_port)
 
     # Create a MQTT connection from the command line data
     mqtt_connection = mqtt_connection_builder.mtls_from_path(
@@ -46,8 +46,7 @@ if __name__ == '__main__':
         http_proxy_options=proxy_options)
 
     if not cmdData.input_isCI:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/basic_connect.py
+++ b/samples/basic_connect.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
         keep_alive_secs=30,
         http_proxy_options=proxy_options)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -18,27 +18,27 @@ allowed_actions = ['both', 'publish', 'subscribe']
 cmdData = CommandLineUtils.parse_sample_input_basic_discovery()
 
 tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(cmdData.input_cert, cmdData.input_key)
-if (cmdData.input_ca != None):
+if (cmdData.input_ca is not None):
     tls_options.override_default_trust_store_from_path(None, cmdData.input_ca)
 tls_context = io.ClientTlsContext(tls_options)
 
 socket_options = io.SocketOptions()
 
 proxy_options = None
-if cmdData.input_proxyHost != None and cmdData.input_proxyPort != 0:
-    proxy_options = http.HttpProxyOptions(cmdData.input_proxyHost, cmdData.input_proxyPort)
+if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
+    proxy_options = http.HttpProxyOptions(cmdData.input_proxy_host, cmdData.input_proxy_port)
 
 print('Performing greengrass discovery...')
 discovery_client = DiscoveryClient(
     io.ClientBootstrap.get_or_create_static_default(),
     socket_options,
     tls_context,
-    cmdData.input_signingRegion, None, proxy_options)
-resp_future = discovery_client.discover(cmdData.input_thingName)
+    cmdData.input_signing_region, None, proxy_options)
+resp_future = discovery_client.discover(cmdData.input_thing_name)
 discover_response = resp_future.result()
 
 print(discover_response)
-if (cmdData.input_printDiscoveryRespOnly == True):
+if (cmdData.input_print_discovery_resp_only):
     exit(0)
 
 
@@ -56,7 +56,8 @@ def try_iot_endpoints():
         for gg_core in gg_group.cores:
             for connectivity_info in gg_core.connectivity:
                 try:
-                    print (f"Trying core {gg_core.thing_arn} at host {connectivity_info.host_address} port {connectivity_info.port}")
+                    print(
+                        f"Trying core {gg_core.thing_arn} at host {connectivity_info.host_address} port {connectivity_info.port}")
                     mqtt_connection = mqtt_connection_builder.mtls_from_path(
                         endpoint=connectivity_info.host_address,
                         port=connectivity_info.port,
@@ -80,6 +81,7 @@ def try_iot_endpoints():
 
     exit('All connection attempts failed')
 
+
 mqtt_connection = try_iot_endpoints()
 
 if cmdData.input_mode == 'both' or cmdData.input_mode == 'subscribe':
@@ -90,7 +92,7 @@ if cmdData.input_mode == 'both' or cmdData.input_mode == 'subscribe':
     subscribe_result = subscribe_future.result()
 
 loop_count = 0
-while loop_count < cmdData.input_maxPubOps:
+while loop_count < cmdData.input_max_pub_ops:
     if cmdData.input_mode == 'both' or cmdData.input_mode == 'publish':
         message = {}
         message['message'] = cmdData.input_message

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -3,64 +3,42 @@
 
 import time
 import json
-from concurrent.futures import Future
 from awscrt import io, http
 from awscrt.mqtt import QoS
 from awsiot.greengrass_discovery import DiscoveryClient
 from awsiot import mqtt_connection_builder
 
+from utils.command_line_utils import CommandLineUtils
+
 allowed_actions = ['both', 'publish', 'subscribe']
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("Basic Discovery - Greengrass discovery example.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_topic_message_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("key", "<path>", "Path to your key in PEM format.", True, str)
-cmdUtils.register_command("cert", "<path>", "Path to your client certificate in PEM format.", True, str)
-cmdUtils.remove_command("endpoint")
-cmdUtils.register_command("thing_name", "<str>", "The name assigned to your IoT Thing", required=True)
-cmdUtils.register_command(
-    "mode", "<mode>",
-    f"The operation mode (optional, default='both').\nModes:{allowed_actions}", default='both')
-cmdUtils.register_command("region", "<str>", "The region to connect through.", required=True)
-cmdUtils.register_command(
-    "max_pub_ops", "<int>",
-    "The maximum number of publish operations (optional, default='10').",
-    default=10, type=int)
-cmdUtils.register_command(
-    "print_discover_resp_only", "", "(optional, default='False').",
-    default=False, type=bool, action="store_true")
-cmdUtils.add_common_proxy_commands()
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_basic_discovery()
 
-tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(
-    cmdUtils.get_command_required("cert"), cmdUtils.get_command_required("key"))
-if cmdUtils.get_command(cmdUtils.m_cmd_ca_file):
-    tls_options.override_default_trust_store_from_path(None, cmdUtils.get_command(cmdUtils.m_cmd_ca_file))
+tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(cmdData.input_cert, cmdData.input_key)
+if (cmdData.input_ca != None):
+    tls_options.override_default_trust_store_from_path(None, cmdData.input_ca)
 tls_context = io.ClientTlsContext(tls_options)
 
 socket_options = io.SocketOptions()
 
 proxy_options = None
-if cmdUtils.get_command(cmdUtils.m_cmd_proxy_host) != None and cmdUtils.get_command(cmdUtils.m_cmd_proxy_port) != None:
-    proxy_options = http.HttpProxyOptions(
-        cmdUtils.get_command_required(cmdUtils.m_cmd_proxy_host),
-        cmdUtils.get_command_required(cmdUtils.m_cmd_proxy_port))
+if cmdData.input_proxyHost != None and cmdData.input_proxyPort != 0:
+    proxy_options = http.HttpProxyOptions(cmdData.input_proxyHost, cmdData.input_proxyPort)
 
 print('Performing greengrass discovery...')
 discovery_client = DiscoveryClient(
     io.ClientBootstrap.get_or_create_static_default(),
     socket_options,
     tls_context,
-    cmdUtils.get_command_required("region"), None, proxy_options)
-resp_future = discovery_client.discover(cmdUtils.get_command_required("thing_name"))
+    cmdData.input_signingRegion, None, proxy_options)
+resp_future = discovery_client.discover(cmdData.input_thingName)
 discover_response = resp_future.result()
 
 print(discover_response)
-if cmdUtils.get_command("print_discover_resp_only"):
+if (cmdData.input_printDiscoveryRespOnly == True):
     exit(0)
 
 
@@ -82,12 +60,12 @@ def try_iot_endpoints():
                     mqtt_connection = mqtt_connection_builder.mtls_from_path(
                         endpoint=connectivity_info.host_address,
                         port=connectivity_info.port,
-                        cert_filepath=cmdUtils.get_command_required("cert"),
-                        pri_key_filepath=cmdUtils.get_command_required("key"),
+                        cert_filepath=Data.input_cert,
+                        pri_key_filepath=cmdData.input_key,
                         ca_bytes=gg_group.certificate_authorities[0].encode('utf-8'),
                         on_connection_interrupted=on_connection_interupted,
                         on_connection_resumed=on_connection_resumed,
-                        client_id=cmdUtils.get_command_required("thing_name"),
+                        client_id=cmdData.input_clientId,
                         clean_session=False,
                         keep_alive_secs=30)
 
@@ -104,25 +82,23 @@ def try_iot_endpoints():
 
 mqtt_connection = try_iot_endpoints()
 
-if cmdUtils.get_command("mode") == 'both' or cmdUtils.get_command("mode") == 'subscribe':
-
+if cmdData.input_mode == 'both' or cmdData.input_mode == 'subscribe':
     def on_publish(topic, payload, dup, qos, retain, **kwargs):
         print('Publish received on topic {}'.format(topic))
         print(payload)
-
-    subscribe_future, _ = mqtt_connection.subscribe(cmdUtils.get_command("topic"), QoS.AT_MOST_ONCE, on_publish)
+    subscribe_future, _ = mqtt_connection.subscribe(cmdData.input_topic, QoS.AT_MOST_ONCE, on_publish)
     subscribe_result = subscribe_future.result()
 
 loop_count = 0
-while loop_count < cmdUtils.get_command("max_pub_ops"):
-    if cmdUtils.get_command("mode") == 'both' or cmdUtils.get_command("mode") == 'publish':
+while loop_count < cmdData.input_maxPubOps:
+    if cmdData.input_mode == 'both' or cmdData.input_mode == 'publish':
         message = {}
-        message['message'] = cmdUtils.get_command("message")
+        message['message'] = cmdData.input_message
         message['sequence'] = loop_count
         messageJson = json.dumps(message)
-        pub_future, _ = mqtt_connection.publish(cmdUtils.get_command("topic"), messageJson, QoS.AT_MOST_ONCE)
+        pub_future, _ = mqtt_connection.publish(cmdData.input_topic, messageJson, QoS.AT_MOST_ONCE)
         pub_future.result()
-        print('Published topic {}: {}\n'.format(cmdUtils.get_command("topic"), messageJson))
+        print('Published topic {}: {}\n'.format(cmdData.input_topic, messageJson))
 
         loop_count += 1
     time.sleep(1)

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -61,7 +61,7 @@ def try_iot_endpoints():
                     mqtt_connection = mqtt_connection_builder.mtls_from_path(
                         endpoint=connectivity_info.host_address,
                         port=connectivity_info.port,
-                        cert_filepath=Data.input_cert,
+                        cert_filepath=cmdData.input_cert,
                         pri_key_filepath=cmdData.input_key,
                         ca_bytes=gg_group.certificate_authorities[0].encode('utf-8'),
                         on_connection_interrupted=on_connection_interupted,

--- a/samples/cognito_connect.py
+++ b/samples/cognito_connect.py
@@ -1,30 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from uuid import uuid4
+from awscrt import http, auth, io
+from awsiot import mqtt_connection_builder
+
+from utils.command_line_utils import CommandLineUtils
 
 # This sample shows how to create a MQTT connection using Cognito.
 # This sample is intended to be used as a reference for making MQTT connections.
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("Cognito Connect - Make a Cognito MQTT connection.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_proxy_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("signing_region", "<str>",
-                          "The signing region used for the websocket signer",
-                          True, str)
-cmdUtils.register_command("client_id", "<str>",
-                          "Client ID to use for MQTT connection (optional, default='test-*').",
-                          default="test-" + str(uuid4()))
-cmdUtils.register_command("cognito_identity", "<str>",
-                          "The Cognito identity ID to use to connect via Cognito",
-                          True, str)
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
-is_ci = cmdUtils.get_command("is_ci", None) is not None
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_basic_connect()
 
 # Callback when connection is accidentally lost.
 def on_connection_interrupted(connection, error, **kwargs):
@@ -36,20 +24,40 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 
 
 if __name__ == '__main__':
-    # Create a connection using Cognito.
-    # Note: The data for the connection is gotten from cmdUtils.
-    # (see build_cognito_mqtt_connection for implementation)
-    #
+    # Create the proxy options if the data is present in cmdData
+    proxy_options = None
+    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+        proxy_options = http.HttpProxyOptions(
+            host_name=cmdData.input_proxyHost,
+            port=cmdData.input_proxyPort)
+
+    # Create the cognito credentials provider
     # Note: This sample and code assumes that you are using a Cognito identity
     # in the same region as you pass to "--signing_region".
     # If not, you may need to adjust the Cognito endpoint in the cmdUtils.
     # See https://docs.aws.amazon.com/general/latest/gr/cognito_identity.html
     # for all Cognito endpoints.
-    mqtt_connection = cmdUtils.build_cognito_mqtt_connection(on_connection_interrupted, on_connection_resumed)
+    cognito_endpoint = f"cognito-identity.{cmdData.input_signingRegion}.amazonaws.com"
+    credentials_provider = auth.AwsCredentialsProvider.new_cognito(
+        endpoint=cognito_endpoint,
+        identity=cmdData.input_cognitoIdentity,
+        tls_ctx=io.ClientTlsContext(io.TlsContextOptions()))
 
-    if not is_ci:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+    # Create a MQTT connection from the command line data
+    mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
+        endpoint=cmdData.input_endpoint,
+        region=cmdData.input_signingRegion,
+        credentials_provider=credentials_provider,
+        http_proxy_options=proxy_options,
+        ca_filepath=cmdData.input_ca,
+        on_connection_interrupted=on_connection_interrupted,
+        on_connection_resumed=on_connection_resumed,
+        client_id=cmdData.input_clientId,
+        clean_session=False,
+        keep_alive_secs=30)
+
+    if not cmdData.input_isCI:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}")
     else:
         print("Connecting to endpoint with client ID...")
 

--- a/samples/cognito_connect.py
+++ b/samples/cognito_connect.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
         clean_session=False,
         keep_alive_secs=30)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID...")

--- a/samples/cognito_connect.py
+++ b/samples/cognito_connect.py
@@ -48,7 +48,6 @@ if __name__ == '__main__':
         region=cmdData.input_signing_region,
         credentials_provider=credentials_provider,
         http_proxy_options=proxy_options,
-        ca_filepath=cmdData.input_ca,
         on_connection_interrupted=on_connection_interrupted,
         on_connection_resumed=on_connection_resumed,
         client_id=cmdData.input_clientId,

--- a/samples/cognito_connect.py
+++ b/samples/cognito_connect.py
@@ -11,7 +11,7 @@ from utils.command_line_utils import CommandLineUtils
 # cmdData is the arguments/input from the command line placed into a single struct for
 # use in this sample. This handles all of the command line parsing, validating, etc.
 # See the Utils/CommandLineUtils for more information.
-cmdData = CommandLineUtils.parse_sample_input_basic_connect()
+cmdData = CommandLineUtils.parse_sample_input_cognito_connect()
 
 # Callback when connection is accidentally lost.
 def on_connection_interrupted(connection, error, **kwargs):
@@ -25,10 +25,10 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 if __name__ == '__main__':
     # Create the proxy options if the data is present in cmdData
     proxy_options = None
-    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+    if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=cmdData.input_proxyHost,
-            port=cmdData.input_proxyPort)
+            host_name=cmdData.input_proxy_host,
+            port=cmdData.input_proxy_port)
 
     # Create the cognito credentials provider
     # Note: This sample and code assumes that you are using a Cognito identity
@@ -36,16 +36,16 @@ if __name__ == '__main__':
     # If not, you may need to adjust the Cognito endpoint in the cmdUtils.
     # See https://docs.aws.amazon.com/general/latest/gr/cognito_identity.html
     # for all Cognito endpoints.
-    cognito_endpoint = f"cognito-identity.{cmdData.input_signingRegion}.amazonaws.com"
+    cognito_endpoint = f"cognito-identity.{cmdData.input_signing_region}.amazonaws.com"
     credentials_provider = auth.AwsCredentialsProvider.new_cognito(
         endpoint=cognito_endpoint,
-        identity=cmdData.input_cognitoIdentity,
+        identity=cmdData.input_cognito_identity,
         tls_ctx=io.ClientTlsContext(io.TlsContextOptions()))
 
     # Create a MQTT connection from the command line data
     mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
         endpoint=cmdData.input_endpoint,
-        region=cmdData.input_signingRegion,
+        region=cmdData.input_signing_region,
         credentials_provider=credentials_provider,
         http_proxy_options=proxy_options,
         ca_filepath=cmdData.input_ca,
@@ -56,7 +56,7 @@ if __name__ == '__main__':
         keep_alive_secs=30)
 
     if not cmdData.input_isCI:
-        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}")
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID...")
 

--- a/samples/cognito_connect.py
+++ b/samples/cognito_connect.py
@@ -3,7 +3,6 @@
 
 from awscrt import http, auth, io
 from awsiot import mqtt_connection_builder
-
 from utils.command_line_utils import CommandLineUtils
 
 # This sample shows how to create a MQTT connection using Cognito.

--- a/samples/custom_authorizer_connect.py
+++ b/samples/custom_authorizer_connect.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
         clean_session=False,
         keep_alive_secs=30)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/custom_authorizer_connect.py
+++ b/samples/custom_authorizer_connect.py
@@ -28,18 +28,18 @@ if __name__ == '__main__':
     mqtt_connection = mqtt_connection_builder.direct_with_custom_authorizer(
         endpoint=cmdData.input_endpoint,
         ca_filepath=cmdData.input_ca,
-        auth_username=cmdData.input_customAuthUsername,
-        auth_authorizer_name=cmdData.input_customAuthorizerName,
-        auth_authorizer_signature=cmdData.input_customAuthorizerSignature,
-        auth_password=cmdData.input_customAuthPassword,
+        auth_username=cmdData.input_custom_auth_username,
+        auth_authorizer_name=cmdData.input_custom_authorizer_name,
+        auth_authorizer_signature=cmdData.input_custom_authorizer_signature,
+        auth_password=cmdData.input_custom_auth_password,
         on_connection_interrupted=on_connection_interrupted,
         on_connection_resumed=on_connection_resumed,
         client_id=cmdData.input_clientId,
         clean_session=False,
         keep_alive_secs=30)
 
-    if cmdData.input_isCI == False:
-        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}")
+    if not cmdData.input_isCI:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/custom_authorizer_connect.py
+++ b/samples/custom_authorizer_connect.py
@@ -27,7 +27,6 @@ if __name__ == '__main__':
     # Create MQTT connection with a custom authorizer
     mqtt_connection = mqtt_connection_builder.direct_with_custom_authorizer(
         endpoint=cmdData.input_endpoint,
-        ca_filepath=cmdData.input_ca,
         auth_username=cmdData.input_custom_auth_username,
         auth_authorizer_name=cmdData.input_custom_authorizer_name,
         auth_authorizer_signature=cmdData.input_custom_authorizer_signature,

--- a/samples/custom_authorizer_connect.py
+++ b/samples/custom_authorizer_connect.py
@@ -2,25 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 from awsiot import mqtt_connection_builder
-from uuid import uuid4
+from utils.command_line_utils import CommandLineUtils
 
 # This sample is similar to `samples/basic_connect.py` but it connects
 # through a custom authorizer rather than using a key and certificate.
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils(
-    "Custom Authorizer Connect - Make a MQTT connection using a custom authorizer.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.add_common_custom_authorizer_commands()
-cmdUtils.register_command("client_id", "<str>",
-                          "Client ID to use for MQTT connection (optional, default='test-*').",
-                          default="test-" + str(uuid4()))
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
-is_ci = cmdUtils.get_command("is_ci", None) != None
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_custom_authorizer_connect()
 
 
 def on_connection_interrupted(connection, error, **kwargs):
@@ -34,24 +24,22 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 
 
 if __name__ == '__main__':
-
     # Create MQTT connection with a custom authorizer
     mqtt_connection = mqtt_connection_builder.direct_with_custom_authorizer(
-        endpoint=cmdUtils.get_command_required(cmdUtils.m_cmd_endpoint),
-        ca_filepath=cmdUtils.get_command(cmdUtils.m_cmd_ca_file),
-        auth_username=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_username),
-        auth_authorizer_name=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_authorizer_name),
-        auth_authorizer_signature=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_authorizer_signature),
-        auth_password=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_password),
+        endpoint=cmdData.input_endpoint,
+        ca_filepath=cmdData.input_ca,
+        auth_username=cmdData.input_customAuthUsername,
+        auth_authorizer_name=cmdData.input_customAuthorizerName,
+        auth_authorizer_signature=cmdData.input_customAuthorizerSignature,
+        auth_password=cmdData.input_customAuthPassword,
         on_connection_interrupted=on_connection_interrupted,
         on_connection_resumed=on_connection_resumed,
-        client_id=cmdUtils.get_command("client_id"),
+        client_id=cmdData.input_clientId,
         clean_session=False,
         keep_alive_secs=30)
 
-    if is_ci == False:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+    if cmdData.input_isCI == False:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/fleetprovisioning.py
+++ b/samples/fleetprovisioning.py
@@ -36,7 +36,6 @@ identity_client = None
 createKeysAndCertificateResponse = None
 createCertificateFromCsrResponse = None
 registerThingResponse = None
-is_ci = cmdData.input_isCI
 
 
 class LockedData:
@@ -109,7 +108,7 @@ def createkeysandcertificate_execution_accepted(response):
     try:
         global createKeysAndCertificateResponse
         createKeysAndCertificateResponse = response
-        if (is_ci == False):
+        if (cmdData.input_is_ci == False):
             print("Received a new message {}".format(createKeysAndCertificateResponse))
 
         return
@@ -129,7 +128,7 @@ def createcertificatefromcsr_execution_accepted(response):
     try:
         global createCertificateFromCsrResponse
         createCertificateFromCsrResponse = response
-        if (is_ci == False):
+        if (cmdData.input_is_ci == False):
             print("Received a new message {}".format(createCertificateFromCsrResponse))
         global certificateOwnershipToken
         certificateOwnershipToken = response.certificate_ownership_token
@@ -151,7 +150,7 @@ def registerthing_execution_accepted(response):
     try:
         global registerThingResponse
         registerThingResponse = response
-        if (is_ci == False):
+        if (cmdData.input_is_ci == False):
             print("Received a new message {} ".format(registerThingResponse))
         return
 
@@ -197,7 +196,7 @@ def waitForCreateKeysAndCertificateResponse():
     while loopCount < 10 and createKeysAndCertificateResponse is None:
         if createKeysAndCertificateResponse is not None:
             break
-        if not is_ci:
+        if not cmdData.input_is_ci:
             print('Waiting... CreateKeysAndCertificateResponse: ' + json.dumps(createKeysAndCertificateResponse))
         else:
             print("Waiting... CreateKeysAndCertificateResponse: ...")
@@ -211,7 +210,7 @@ def waitForCreateCertificateFromCsrResponse():
     while loopCount < 10 and createCertificateFromCsrResponse is None:
         if createCertificateFromCsrResponse is not None:
             break
-        if not is_ci:
+        if not cmdData.input_is_ci:
             print('Waiting...CreateCertificateFromCsrResponse: ' + json.dumps(createCertificateFromCsrResponse))
         else:
             print("Waiting... CreateCertificateFromCsrResponse: ...")
@@ -226,7 +225,7 @@ def waitForRegisterThingResponse():
         if registerThingResponse is not None:
             break
         loopCount += 1
-        if not is_ci:
+        if not cmdData.input_is_ci:
             print('Waiting... RegisterThingResponse: ' + json.dumps(registerThingResponse))
         else:
             print('Waiting... RegisterThingResponse: ...')
@@ -255,7 +254,7 @@ if __name__ == '__main__':
         keep_alive_secs=30,
         http_proxy_options=proxy_options)
 
-    if not is_ci:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/fleetprovisioning.py
+++ b/samples/fleetprovisioning.py
@@ -119,7 +119,7 @@ def createkeysandcertificate_execution_accepted(response):
 
 def createkeysandcertificate_execution_rejected(rejected):
     # type: (iotidentity.RejectedError) -> None
-    exit("CreateKeysAndCertificate Request rejected with code:'{}' message:'{}' statuscode:'{}'".format(
+    exit("CreateKeysAndCertificate Request rejected with code:'{}' message:'{}' status code:'{}'".format(
         rejected.error_code, rejected.error_message, rejected.status_code))
 
 
@@ -141,7 +141,7 @@ def createcertificatefromcsr_execution_accepted(response):
 
 def createcertificatefromcsr_execution_rejected(rejected):
     # type: (iotidentity.RejectedError) -> None
-    exit("CreateCertificateFromCsr Request rejected with code:'{}' message:'{}' statuscode:'{}'".format(
+    exit("CreateCertificateFromCsr Request rejected with code:'{}' message:'{}' status code:'{}'".format(
         rejected.error_code, rejected.error_message, rejected.status_code))
 
 
@@ -160,7 +160,7 @@ def registerthing_execution_accepted(response):
 
 def registerthing_execution_rejected(rejected):
     # type: (iotidentity.RejectedError) -> None
-    exit("RegisterThing Request rejected with code:'{}' message:'{}' statuscode:'{}'".format(
+    exit("RegisterThing Request rejected with code:'{}' message:'{}' status code:'{}'".format(
         rejected.error_code, rejected.error_message, rejected.status_code))
 
 # Callback when connection is accidentally lost.

--- a/samples/fleetprovisioning.py
+++ b/samples/fleetprovisioning.py
@@ -27,7 +27,7 @@ from utils.command_line_utils import CommandLineUtils
 # cmdData is the arguments/input from the command line placed into a single struct for
 # use in this sample. This handles all of the command line parsing, validating, etc.
 # See the Utils/CommandLineUtils for more information.
-cmdData = CommandLineUtils.parse_sample_input_custom_authorizer_connect()
+cmdData = CommandLineUtils.parse_sample_input_fleet_provisioning()
 
 # Using globals to simplify sample code
 is_sample_done = threading.Event()
@@ -38,10 +38,12 @@ createCertificateFromCsrResponse = None
 registerThingResponse = None
 is_ci = cmdData.input_isCI
 
+
 class LockedData:
     def __init__(self):
         self.lock = threading.Lock()
         self.disconnect_called = False
+
 
 locked_data = LockedData()
 
@@ -60,6 +62,7 @@ def exit(msg_or_exception):
             future = mqtt_connection.disconnect()
             future.add_done_callback(on_disconnected)
 
+
 def on_disconnected(disconnect_future):
     # type: (Future) -> None
     print("Disconnected.")
@@ -67,35 +70,39 @@ def on_disconnected(disconnect_future):
     # Signal that sample is finished
     is_sample_done.set()
 
+
 def on_publish_register_thing(future):
     # type: (Future) -> None
     try:
-        future.result() # raises exception if publish failed
+        future.result()  # raises exception if publish failed
         print("Published RegisterThing request..")
 
     except Exception as e:
         print("Failed to publish RegisterThing request.")
         exit(e)
 
+
 def on_publish_create_keys_and_certificate(future):
     # type: (Future) -> None
     try:
-        future.result() # raises exception if publish failed
+        future.result()  # raises exception if publish failed
         print("Published CreateKeysAndCertificate request..")
 
     except Exception as e:
         print("Failed to publish CreateKeysAndCertificate request.")
         exit(e)
 
+
 def on_publish_create_certificate_from_csr(future):
     # type: (Future) -> None
     try:
-        future.result() # raises exception if publish failed
+        future.result()  # raises exception if publish failed
         print("Published CreateCertificateFromCsr request..")
 
     except Exception as e:
         print("Failed to publish CreateCertificateFromCsr request.")
         exit(e)
+
 
 def createkeysandcertificate_execution_accepted(response):
     # type: (iotidentity.CreateKeysAndCertificateResponse) -> None
@@ -110,10 +117,12 @@ def createkeysandcertificate_execution_accepted(response):
     except Exception as e:
         exit(e)
 
+
 def createkeysandcertificate_execution_rejected(rejected):
     # type: (iotidentity.RejectedError) -> None
     exit("CreateKeysAndCertificate Request rejected with code:'{}' message:'{}' statuscode:'{}'".format(
         rejected.error_code, rejected.error_message, rejected.status_code))
+
 
 def createcertificatefromcsr_execution_accepted(response):
     # type: (iotidentity.CreateCertificateFromCsrResponse) -> None
@@ -130,10 +139,12 @@ def createcertificatefromcsr_execution_accepted(response):
     except Exception as e:
         exit(e)
 
+
 def createcertificatefromcsr_execution_rejected(rejected):
     # type: (iotidentity.RejectedError) -> None
     exit("CreateCertificateFromCsr Request rejected with code:'{}' message:'{}' statuscode:'{}'".format(
         rejected.error_code, rejected.error_message, rejected.status_code))
+
 
 def registerthing_execution_accepted(response):
     # type: (iotidentity.RegisterThingResponse) -> None
@@ -146,6 +157,7 @@ def registerthing_execution_accepted(response):
 
     except Exception as e:
         exit(e)
+
 
 def registerthing_execution_rejected(rejected):
     # type: (iotidentity.RejectedError) -> None
@@ -169,6 +181,7 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
         # evaluate result with a callback instead.
         resubscribe_future.add_done_callback(on_resubscribe_complete)
 
+
 def on_resubscribe_complete(resubscribe_future):
     resubscribe_results = resubscribe_future.result()
     print("Resubscribe results: {}".format(resubscribe_results))
@@ -177,18 +190,20 @@ def on_resubscribe_complete(resubscribe_future):
         if qos is None:
             sys.exit("Server rejected resubscribe to topic: {}".format(topic))
 
+
 def waitForCreateKeysAndCertificateResponse():
     # Wait for the response.
     loopCount = 0
     while loopCount < 10 and createKeysAndCertificateResponse is None:
         if createKeysAndCertificateResponse is not None:
             break
-        if is_ci == False:
+        if not is_ci:
             print('Waiting... CreateKeysAndCertificateResponse: ' + json.dumps(createKeysAndCertificateResponse))
         else:
             print("Waiting... CreateKeysAndCertificateResponse: ...")
         loopCount += 1
         time.sleep(1)
+
 
 def waitForCreateCertificateFromCsrResponse():
     # Wait for the response.
@@ -196,12 +211,13 @@ def waitForCreateCertificateFromCsrResponse():
     while loopCount < 10 and createCertificateFromCsrResponse is None:
         if createCertificateFromCsrResponse is not None:
             break
-        if is_ci == False:
+        if not is_ci:
             print('Waiting...CreateCertificateFromCsrResponse: ' + json.dumps(createCertificateFromCsrResponse))
         else:
             print("Waiting... CreateCertificateFromCsrResponse: ...")
         loopCount += 1
         time.sleep(1)
+
 
 def waitForRegisterThingResponse():
     # Wait for the response.
@@ -210,19 +226,20 @@ def waitForRegisterThingResponse():
         if registerThingResponse is not None:
             break
         loopCount += 1
-        if is_ci == False:
+        if not is_ci:
             print('Waiting... RegisterThingResponse: ' + json.dumps(registerThingResponse))
         else:
             print('Waiting... RegisterThingResponse: ...')
         time.sleep(1)
 
+
 if __name__ == '__main__':
     # Create the proxy options if the data is present in cmdData
     proxy_options = None
-    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+    if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=cmdData.input_proxyHost,
-            port=cmdData.input_proxyPort)
+            host_name=cmdData.input_proxy_host,
+            port=cmdData.input_proxy_port)
 
     # Create a MQTT connection from the command line data
     mqtt_connection = mqtt_connection_builder.mtls_from_path(
@@ -238,8 +255,8 @@ if __name__ == '__main__':
         keep_alive_secs=30,
         http_proxy_options=proxy_options)
 
-    if is_ci == False:
-        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'")
+    if not is_ci:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 
@@ -261,7 +278,7 @@ if __name__ == '__main__':
         # to succeed before publishing the corresponding "request".
 
         # Keys workflow if csr is not provided
-        if cmdData.input_csrPath is None:
+        if cmdData.input_csr_path is None:
             createkeysandcertificate_subscription_request = iotidentity.CreateKeysAndCertificateSubscriptionRequest()
 
             print("Subscribing to CreateKeysAndCertificate Accepted topic...")
@@ -302,8 +319,8 @@ if __name__ == '__main__':
             # Wait for subscription to succeed
             createcertificatefromcsr_subscribed_rejected_future.result()
 
-
-        registerthing_subscription_request = iotidentity.RegisterThingSubscriptionRequest(template_name= cmdData.input_templateName)
+        registerthing_subscription_request = iotidentity.RegisterThingSubscriptionRequest(
+            template_name=cmdData.input_template_name)
 
         print("Subscribing to RegisterThing Accepted topic...")
         registerthing_subscribed_accepted_future, _ = identity_client.subscribe_to_register_thing_accepted(
@@ -322,9 +339,9 @@ if __name__ == '__main__':
         # Wait for subscription to succeed
         registerthing_subscribed_rejected_future.result()
 
-        fleet_template_name = cmdData.input_templateName
-        fleet_template_parameters = cmdData.input_templateParameters
-        if cmdData.input_csrPath is None:
+        fleet_template_name = cmdData.input_template_name
+        fleet_template_parameters = cmdData.input_template_parameters
+        if cmdData.input_csr_path is None:
             print("Publishing to CreateKeysAndCertificate...")
             publish_future = identity_client.publish_create_keys_and_certificate(
                 request=iotidentity.CreateKeysAndCertificateRequest(), qos=mqtt.QoS.AT_LEAST_ONCE)
@@ -341,7 +358,7 @@ if __name__ == '__main__':
                 parameters=json.loads(fleet_template_parameters))
         else:
             print("Publishing to CreateCertificateFromCsr...")
-            csrPath = open(cmdData.input_csrPath, 'r').read()
+            csrPath = open(cmdData.input_csr_path, 'r').read()
             publish_future = identity_client.publish_create_certificate_from_csr(
                 request=iotidentity.CreateCertificateFromCsrRequest(certificate_signing_request=csrPath),
                 qos=mqtt.QoS.AT_LEAST_ONCE)
@@ -358,7 +375,8 @@ if __name__ == '__main__':
                 parameters=json.loads(fleet_template_parameters))
 
         print("Publishing to RegisterThing topic...")
-        registerthing_publish_future = identity_client.publish_register_thing(registerThingRequest, mqtt.QoS.AT_LEAST_ONCE)
+        registerthing_publish_future = identity_client.publish_register_thing(
+            registerThingRequest, mqtt.QoS.AT_LEAST_ONCE)
         registerthing_publish_future.add_done_callback(on_publish_register_thing)
 
         waitForRegisterThingResponse()
@@ -369,4 +387,3 @@ if __name__ == '__main__':
 
     # Wait for the sample to finish
     is_sample_done.wait()
-

--- a/samples/jobs.py
+++ b/samples/jobs.py
@@ -1,15 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from awscrt import mqtt
-from awsiot import iotjobs
+from awscrt import mqtt, http
+from awsiot import iotjobs, mqtt_connection_builder
 from concurrent.futures import Future
 import sys
 import threading
 import time
 import traceback
 import time
-from uuid import uuid4
+from utils.command_line_utils import CommandLineUtils
 
 # - Overview -
 # This sample uses the AWS IoT Jobs Service to get a list of pending jobs and
@@ -37,26 +37,14 @@ from uuid import uuid4
 # Using globals to simplify sample code
 is_sample_done = threading.Event()
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("Jobs - Recieve and execute operations on the device.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_proxy_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("key", "<path>", "Path to your key in PEM format.", True, str)
-cmdUtils.register_command("cert", "<path>", "Path to your client certificate in PEM format.", True, str)
-cmdUtils.register_command("client_id", "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
-cmdUtils.register_command("port", "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
-cmdUtils.register_command("thing_name", "<str>", "The name assigned to your IoT Thing", required=True)
-cmdUtils.register_command("job_time", "<int>", "Emulate working on a job by sleeping this many seconds (optional, default='5')", default=5, type=int)
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None'. Will just describe job if set)")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_custom_authorizer_connect()
 
 mqtt_connection = None
 jobs_client = None
-jobs_thing_name = cmdUtils.get_command_required("thing_name")
-is_ci = cmdUtils.get_command("is_ci", None) != None
+jobs_thing_name = cmdData.input_thingName
 
 class LockedData:
     def __init__(self):
@@ -203,7 +191,7 @@ def on_start_next_pending_job_execution_rejected(rejected):
 def job_thread_fn(job_id, job_document):
     try:
         print("Starting local work on job...")
-        time.sleep(cmdUtils.get_command("job_time"))
+        time.sleep(cmdData.input_jobTime)
         print("Done working on job.")
 
         print("Publishing request to update job status to SUCCEEDED...")
@@ -240,10 +228,28 @@ def on_update_job_execution_rejected(rejected):
         rejected.code, rejected.message))
 
 if __name__ == '__main__':
-    mqtt_connection = cmdUtils.build_mqtt_connection(None, None)
-    if is_ci == False:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+
+    # Create the proxy options if the data is present in cmdData
+    proxy_options = None
+    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+        proxy_options = http.HttpProxyOptions(
+            host_name=cmdData.input_proxyHost,
+            port=cmdData.input_proxyPort)
+
+    # Create a MQTT connection from the command line data
+    mqtt_connection = mqtt_connection_builder.mtls_from_path(
+        endpoint=cmdData.input_endpoint,
+        port=cmdData.input_port,
+        cert_filepath=cmdData.input_cert,
+        pri_key_filepath=cmdData.input_key,
+        ca_filepath=cmdData.input_ca,
+        client_id=cmdData.input_clientId,
+        clean_session=False,
+        keep_alive_secs=30,
+        http_proxy_options=proxy_options)
+
+    if cmdData.input_isCI == False:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'")
     else:
         print("Connecting to endpoint with client ID")
 
@@ -289,7 +295,7 @@ if __name__ == '__main__':
         exit(e)
 
     # If we are running in CI, then we want to check how many jobs were reported and stop
-    if (is_ci):
+    if (cmdData.input_isCI):
         # Wait until we get a response. If we do not get a response after 50 tries, then abort
         got_job_response_tries = 0
         while (locked_data.got_job_response == False):

--- a/samples/jobs.py
+++ b/samples/jobs.py
@@ -265,7 +265,7 @@ if __name__ == '__main__':
         keep_alive_secs=30,
         http_proxy_options=proxy_options)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
@@ -312,7 +312,7 @@ if __name__ == '__main__':
         exit(e)
 
     # If we are running in CI, then we want to check how many jobs were reported and stop
-    if (cmdData.input_isCI):
+    if (cmdData.input_is_ci):
         # Wait until we get a response. If we do not get a response after 50 tries, then abort
         got_job_response_tries = 0
         while (locked_data.got_job_response == False):

--- a/samples/jobs.py
+++ b/samples/jobs.py
@@ -40,11 +40,12 @@ is_sample_done = threading.Event()
 # cmdData is the arguments/input from the command line placed into a single struct for
 # use in this sample. This handles all of the command line parsing, validating, etc.
 # See the Utils/CommandLineUtils for more information.
-cmdData = CommandLineUtils.parse_sample_input_custom_authorizer_connect()
+cmdData = CommandLineUtils.parse_sample_input_jobs()
 
 mqtt_connection = None
 jobs_client = None
-jobs_thing_name = cmdData.input_thingName
+jobs_thing_name = cmdData.input_thing_name
+
 
 class LockedData:
     def __init__(self):
@@ -53,6 +54,7 @@ class LockedData:
         self.is_working_on_job = False
         self.is_next_job_waiting = False
         self.got_job_response = False
+
 
 locked_data = LockedData()
 
@@ -70,6 +72,7 @@ def exit(msg_or_exception):
             locked_data.disconnect_called = True
             future = mqtt_connection.disconnect()
             future.add_done_callback(on_disconnected)
+
 
 def try_start_next_job():
     print("Trying to start the next job...")
@@ -90,6 +93,7 @@ def try_start_next_job():
     publish_future = jobs_client.publish_start_next_pending_job_execution(request, mqtt.QoS.AT_LEAST_ONCE)
     publish_future.add_done_callback(on_publish_start_next_pending_job_execution)
 
+
 def done_working_on_job():
     with locked_data.lock:
         locked_data.is_working_on_job = False
@@ -98,6 +102,7 @@ def done_working_on_job():
     if try_again:
         try_start_next_job()
 
+
 def on_disconnected(disconnect_future):
     # type: (Future) -> None
     print("Disconnected.")
@@ -105,26 +110,30 @@ def on_disconnected(disconnect_future):
     # Signal that sample is finished
     is_sample_done.set()
 
+
 # A list to hold all the pending jobs
 available_jobs = []
+
+
 def on_get_pending_job_executions_accepted(response):
     # type: (iotjobs.GetPendingJobExecutionsResponse) -> None
     with locked_data.lock:
         if (len(response.queued_jobs) > 0 or len(response.in_progress_jobs) > 0):
-            print ("Pending Jobs:")
+            print("Pending Jobs:")
             for job in response.in_progress_jobs:
                 available_jobs.append(job)
                 print(f"  In Progress: {job.job_id} @ {job.last_updated_at}")
             for job in response.queued_jobs:
                 available_jobs.append(job)
-                print (f"  {job.job_id} @ {job.last_updated_at}")
+                print(f"  {job.job_id} @ {job.last_updated_at}")
         else:
-            print ("No pending or queued jobs found!")
+            print("No pending or queued jobs found!")
         locked_data.got_job_response = True
+
 
 def on_get_pending_job_executions_rejected(error):
     # type: (iotjobs.RejectedError) -> None
-    print (f"Request rejected: {error.code}: {error.message}")
+    print(f"Request rejected: {error.code}: {error.message}")
     exit("Get pending jobs request rejected!")
 
 
@@ -153,15 +162,17 @@ def on_next_job_execution_changed(event):
     except Exception as e:
         exit(e)
 
+
 def on_publish_start_next_pending_job_execution(future):
     # type: (Future) -> None
     try:
-        future.result() # raises exception if publish failed
+        future.result()  # raises exception if publish failed
 
         print("Published request to start the next job.")
 
     except Exception as e:
         exit(e)
+
 
 def on_start_next_pending_job_execution_accepted(response):
     # type: (iotjobs.StartNextJobExecutionResponse) -> None
@@ -183,15 +194,17 @@ def on_start_next_pending_job_execution_accepted(response):
     except Exception as e:
         exit(e)
 
+
 def on_start_next_pending_job_execution_rejected(rejected):
     # type: (iotjobs.RejectedError) -> None
     exit("Request to start next pending job rejected with code:'{}' message:'{}'".format(
         rejected.code, rejected.message))
 
+
 def job_thread_fn(job_id, job_document):
     try:
         print("Starting local work on job...")
-        time.sleep(cmdData.input_jobTime)
+        time.sleep(cmdData.input_job_time)
         print("Done working on job.")
 
         print("Publishing request to update job status to SUCCEEDED...")
@@ -205,14 +218,16 @@ def job_thread_fn(job_id, job_document):
     except Exception as e:
         exit(e)
 
+
 def on_publish_update_job_execution(future):
     # type: (Future) -> None
     try:
-        future.result() # raises exception if publish failed
+        future.result()  # raises exception if publish failed
         print("Published request to update job.")
 
     except Exception as e:
         exit(e)
+
 
 def on_update_job_execution_accepted(response):
     # type: (iotjobs.UpdateJobExecutionResponse) -> None
@@ -222,19 +237,21 @@ def on_update_job_execution_accepted(response):
     except Exception as e:
         exit(e)
 
+
 def on_update_job_execution_rejected(rejected):
     # type: (iotjobs.RejectedError) -> None
     exit("Request to update job status was rejected. code:'{}' message:'{}'.".format(
         rejected.code, rejected.message))
 
+
 if __name__ == '__main__':
 
     # Create the proxy options if the data is present in cmdData
     proxy_options = None
-    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+    if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=cmdData.input_proxyHost,
-            port=cmdData.input_proxyPort)
+            host_name=cmdData.input_proxy_host,
+            port=cmdData.input_proxy_port)
 
     # Create a MQTT connection from the command line data
     mqtt_connection = mqtt_connection_builder.mtls_from_path(
@@ -248,8 +265,8 @@ if __name__ == '__main__':
         keep_alive_secs=30,
         http_proxy_options=proxy_options)
 
-    if cmdData.input_isCI == False:
-        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'")
+    if not cmdData.input_isCI:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 
@@ -306,10 +323,10 @@ if __name__ == '__main__':
             time.sleep(0.2)
 
         if (len(available_jobs) > 0):
-            print ("At least one job queued in CI! No further work to do. Exiting sample...")
+            print("At least one job queued in CI! No further work to do. Exiting sample...")
             sys.exit(0)
         else:
-            print ("ERROR: No jobs queued in CI! At least one job should be queued!")
+            print("ERROR: No jobs queued in CI! At least one job should be queued!")
             sys.exit(-1)
 
     try:
@@ -349,8 +366,8 @@ if __name__ == '__main__':
         # Note that we subscribe to "+", the MQTT wildcard, to receive
         # responses about any job-ID.
         update_subscription_request = iotjobs.UpdateJobExecutionSubscriptionRequest(
-                thing_name=jobs_thing_name,
-                job_id='+')
+            thing_name=jobs_thing_name,
+            job_id='+')
 
         subscribed_accepted_future, _ = jobs_client.subscribe_to_update_job_execution_accepted(
             request=update_subscription_request,

--- a/samples/mqtt5_custom_authorizer_connect.py
+++ b/samples/mqtt5_custom_authorizer_connect.py
@@ -49,7 +49,6 @@ if __name__ == '__main__':
     else:
         client = mqtt5_client_builder.websockets_with_custom_authorizer(
             endpoint=cmdData.input_endpoint,
-            ca_filepath=cmdData.input_ca,
             region=cmdData.input_signing_region,
             auth_username=cmdData.input_custom_auth_username,
             auth_authorizer_name=cmdData.input_custom_authorizer_name,

--- a/samples/mqtt5_custom_authorizer_connect.py
+++ b/samples/mqtt5_custom_authorizer_connect.py
@@ -11,7 +11,7 @@ TIMEOUT = 100
 # cmdData is the arguments/input from the command line placed into a single struct for
 # use in this sample. This handles all of the command line parsing, validating, etc.
 # See the Utils/CommandLineUtils for more information.
-cmdData = CommandLineUtils.parse_sample_input_custom_authorizer_connect()
+cmdData = CommandLineUtils.parse_sample_input_mqtt5_custom_authorizer_connect()
 
 future_stopped = Future()
 future_connection_success = Future()
@@ -29,17 +29,20 @@ def on_lifecycle_connection_success(lifecycle_connect_success_data: mqtt5.Lifecy
     global future_connection_success
     future_connection_success.set_result(lifecycle_connect_success_data)
 
+
 if __name__ == '__main__':
 
     # Create MQTT5 Client with a custom authorizer
-    if cmdData.input_useWebsockets == None:
+    if cmdData.input_use_websockets is None:
         client = mqtt5_client_builder.direct_with_custom_authorizer(
             endpoint=cmdData.input_endpoint,
             ca_filepath=cmdData.input_ca,
-            auth_username=cmdData.input_customAuthUsername,
-            auth_authorizer_name=cmdData.input_customAuthorizerName,
-            auth_authorizer_signature=cmdData.input_customAuthorizerSignature,
-            auth_password=cmdData.input_customAuthPassword,
+            cert_filepath=cmdData.input_cert,
+            pri_key_filepath=cmdData.input_key,
+            auth_username=cmdData.input_custom_auth_username,
+            auth_authorizer_name=cmdData.input_custom_authorizer_name,
+            auth_authorizer_signature=cmdData.input_custom_authorizer_signature,
+            auth_password=cmdData.input_custom_auth_password,
             on_lifecycle_stopped=on_lifecycle_stopped,
             on_lifecycle_connection_success=on_lifecycle_connection_success,
             client_id=cmdData.input_clientId)
@@ -47,16 +50,17 @@ if __name__ == '__main__':
         client = mqtt5_client_builder.websockets_with_custom_authorizer(
             endpoint=cmdData.input_endpoint,
             ca_filepath=cmdData.input_ca,
-            auth_username=cmdData.input_customAuthUsername,
-            auth_authorizer_name=cmdData.input_customAuthorizerName,
-            auth_authorizer_signature=cmdData.input_customAuthorizerSignature,
-            auth_password=cmdData.input_customAuthPassword,
+            region=cmdData.input_signing_region,
+            auth_username=cmdData.input_custom_auth_username,
+            auth_authorizer_name=cmdData.input_custom_authorizer_name,
+            auth_authorizer_signature=cmdData.input_custom_authorizer_signature,
+            auth_password=cmdData.input_custom_auth_password,
             on_lifecycle_stopped=on_lifecycle_stopped,
             on_lifecycle_connection_success=on_lifecycle_connection_success,
             client_id=cmdData.input_clientId)
 
-    if cmdData.input_isCI == False:
-        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'")
+    if not cmdData.input_isCI:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/mqtt5_custom_authorizer_connect.py
+++ b/samples/mqtt5_custom_authorizer_connect.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
             on_lifecycle_connection_success=on_lifecycle_connection_success,
             client_id=cmdData.input_clientId)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/mqtt5_custom_authorizer_connect.py
+++ b/samples/mqtt5_custom_authorizer_connect.py
@@ -3,30 +3,18 @@
 
 from awsiot import mqtt5_client_builder
 from awscrt import mqtt5
-from uuid import uuid4
 from concurrent.futures import Future
+from utils.command_line_utils import CommandLineUtils
 
 TIMEOUT = 100
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils(
-    "Custom Authorizer Connect - Make a MQTT5 Client connection using a custom authorizer.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.add_common_custom_authorizer_commands()
-cmdUtils.register_command("client_id", "<str>",
-                          "Client ID to use for MQTT connection (optional, default='test-*').",
-                          default="test-" + str(uuid4()))
-cmdUtils.register_command("use_websockets", "<str>", "If set, websockets will be used (optional, do not set to use direct MQTT)")
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_custom_authorizer_connect()
 
 future_stopped = Future()
 future_connection_success = Future()
-is_ci = cmdUtils.get_command("is_ci", None) != None
-use_websockets = cmdUtils.get_command("use_websockets", None) != None
 
 # Callback for the lifecycle event Stopped
 def on_lifecycle_stopped(lifecycle_stopped_data: mqtt5.LifecycleStoppedData):
@@ -44,32 +32,31 @@ def on_lifecycle_connection_success(lifecycle_connect_success_data: mqtt5.Lifecy
 if __name__ == '__main__':
 
     # Create MQTT5 Client with a custom authorizer
-    if use_websockets == None:
+    if cmdData.input_useWebsockets == None:
         client = mqtt5_client_builder.direct_with_custom_authorizer(
-            endpoint=cmdUtils.get_command_required(cmdUtils.m_cmd_endpoint),
-            ca_filepath=cmdUtils.get_command(cmdUtils.m_cmd_ca_file),
-            auth_username=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_username),
-            auth_authorizer_name=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_authorizer_name),
-            auth_authorizer_signature=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_authorizer_signature),
-            auth_password=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_password),
+            endpoint=cmdData.input_endpoint,
+            ca_filepath=cmdData.input_ca,
+            auth_username=cmdData.input_customAuthUsername,
+            auth_authorizer_name=cmdData.input_customAuthorizerName,
+            auth_authorizer_signature=cmdData.input_customAuthorizerSignature,
+            auth_password=cmdData.input_customAuthPassword,
             on_lifecycle_stopped=on_lifecycle_stopped,
             on_lifecycle_connection_success=on_lifecycle_connection_success,
-            client_id=cmdUtils.get_command("client_id"))
+            client_id=cmdData.input_clientId)
     else:
         client = mqtt5_client_builder.websockets_with_custom_authorizer(
-            endpoint=cmdUtils.get_command_required(cmdUtils.m_cmd_endpoint),
-            ca_filepath=cmdUtils.get_command(cmdUtils.m_cmd_ca_file),
-            auth_username=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_username),
-            auth_authorizer_name=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_authorizer_name),
-            auth_authorizer_signature=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_authorizer_signature),
-            auth_password=cmdUtils.get_command(cmdUtils.m_cmd_custom_auth_password),
+            endpoint=cmdData.input_endpoint,
+            ca_filepath=cmdData.input_ca,
+            auth_username=cmdData.input_customAuthUsername,
+            auth_authorizer_name=cmdData.input_customAuthorizerName,
+            auth_authorizer_signature=cmdData.input_customAuthorizerSignature,
+            auth_password=cmdData.input_customAuthPassword,
             on_lifecycle_stopped=on_lifecycle_stopped,
             on_lifecycle_connection_success=on_lifecycle_connection_success,
-            client_id=cmdUtils.get_command("client_id"))
+            client_id=cmdData.input_clientId)
 
-    if is_ci == False:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+    if cmdData.input_isCI == False:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/mqtt5_pkcs11_connect.py
+++ b/samples/mqtt5_pkcs11_connect.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
         pkcs11_slot_id = int(cmdData.input_pkcs11_slot_id)
 
     # Create MQTT5 client
-    mqtt5_client = mqtt5_client_builder.mtls_with_pkcs11(
+    client = mqtt5_client_builder.mtls_with_pkcs11(
         pkcs11_lib=pkcs11_lib,
         user_pin=cmdData.input_pkcs11_user_pin,
         slot_id=pkcs11_slot_id,

--- a/samples/mqtt5_pkcs11_connect.py
+++ b/samples/mqtt5_pkcs11_connect.py
@@ -33,24 +33,24 @@ def on_lifecycle_connection_success(lifecycle_connect_success_data: mqtt5.Lifecy
 if __name__ == '__main__':
     print("\nStarting MQTT5 pkcs11 connect Sample\n")
 
-    print(f"Loading PKCS#11 library '{cmdData.input_pkcs11LibPath}' ...")
+    print(f"Loading PKCS#11 library '{cmdData.input_pkcs11_lib_path}' ...")
     pkcs11_lib = io.Pkcs11Lib(
-        file=cmdData.input_pkcs11LibPath,
+        file=cmdData.input_pkcs11_lib_path,
         behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
     print("Loaded!")
 
     pkcs11_slot_id = None
-    if (cmdData.input_pkcs11SlotId is not None):
-        pkcs11_slot_id = int(cmdData.input_pkcs11SlotId)
+    if (cmdData.input_pkcs11_slot_id is not None):
+        pkcs11_slot_id = int(cmdData.input_pkcs11_slot_id)
 
     # Create MQTT5 client
     mqtt5_client = mqtt5_client_builder.mtls_with_pkcs11(
         pkcs11_lib=pkcs11_lib,
-        user_pin=cmdData.input_pkcs11UserPin,
+        user_pin=cmdData.input_pkcs11_user_pin,
         slot_id=pkcs11_slot_id,
-        token_label=cmdData.input_pkcs11TokenLabel,
-        private_key_label=cmdData.input_pkcs11KeyLabel,
-        cert_filepath= cmdData.input_cert,
+        token_label=cmdData.input_pkcs11_token_label,
+        private_key_label=cmdData.input_pkcs11_key_label,
+        cert_filepath=cmdData.input_cert,
         endpoint=cmdData.input_endpoint,
         port=cmdData.input_port,
         ca_filepath=cmdData.input_ca,
@@ -60,8 +60,8 @@ if __name__ == '__main__':
 
     print("MQTT5 Client Created")
 
-    if cmdData.input_isCI == False:
-        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}")
+    if not cmdData.input_isCI:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/mqtt5_pkcs11_connect.py
+++ b/samples/mqtt5_pkcs11_connect.py
@@ -1,41 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from awscrt import mqtt5
-from uuid import uuid4
+from awscrt import mqtt5, io
+from awsiot import mqtt5_client_builder
 from concurrent.futures import Future
+from utils.command_line_utils import CommandLineUtils
 
 TIMEOUT = 100
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("MQTT5 PKCS11 Connect - Make a MQTT5 Client connection using PKCS11.")
-cmdUtils.add_common_mqtt5_commands()
-cmdUtils.add_common_proxy_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("cert", "<path>", "Path to your client certificate in PEM format.", True, str)
-cmdUtils.register_command(
-    "port",
-    "<int>",
-    "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
-    type=int)
-cmdUtils.register_command(
-    "client_id",
-    "<str>",
-    "Client ID to use for MQTT5 connection (optional, default=None).",
-    default="test-" + str(uuid4()))
-cmdUtils.register_command("pkcs11_lib", "<path>", "Path to PKCS#11 Library", required=True)
-cmdUtils.register_command("pin", "<str>", "User PIN for logging into PKCS#11 token.", required=True)
-cmdUtils.register_command("token_label", "<str>", "Label of the PKCS#11 token to use (optional).")
-cmdUtils.register_command("slot_id", "<int>", "Slot ID containing the PKCS#11 token to use (optional).", False, int)
-cmdUtils.register_command("key_label", "<str>", "Label of private key on the PKCS#11 token (optional).")
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_mqtt5_pkcs11_connect()
 
 future_stopped = Future()
 future_connection_success = Future()
-is_ci = cmdUtils.get_command("is_ci", None) != None
 
 # Callback for the lifecycle event Stopped
 def on_lifecycle_stopped(lifecycle_stopped_data: mqtt5.LifecycleStoppedData):
@@ -54,15 +33,35 @@ def on_lifecycle_connection_success(lifecycle_connect_success_data: mqtt5.Lifecy
 if __name__ == '__main__':
     print("\nStarting MQTT5 pkcs11 connect Sample\n")
 
-    # Create MQTT5 Client with using PKCS11
-    client = cmdUtils.build_pkcs11_mqtt5_client(
+    print(f"Loading PKCS#11 library '{cmdData.input_pkcs11LibPath}' ...")
+    pkcs11_lib = io.Pkcs11Lib(
+        file=cmdData.input_pkcs11LibPath,
+        behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
+    print("Loaded!")
+
+    pkcs11_slot_id = None
+    if (cmdData.input_pkcs11SlotId is not None):
+        pkcs11_slot_id = int(cmdData.input_pkcs11SlotId)
+
+    # Create MQTT5 client
+    mqtt5_client = mqtt5_client_builder.mtls_with_pkcs11(
+        pkcs11_lib=pkcs11_lib,
+        user_pin=cmdData.input_pkcs11UserPin,
+        slot_id=pkcs11_slot_id,
+        token_label=cmdData.input_pkcs11TokenLabel,
+        private_key_label=cmdData.input_pkcs11KeyLabel,
+        cert_filepath= cmdData.input_cert,
+        endpoint=cmdData.input_endpoint,
+        port=cmdData.input_port,
+        ca_filepath=cmdData.input_ca,
         on_lifecycle_stopped=on_lifecycle_stopped,
-        on_lifecycle_connection_success=on_lifecycle_connection_success)
+        on_lifecycle_connection_success=on_lifecycle_connection_success,
+        client_id=cmdData.input_clientId)
+
     print("MQTT5 Client Created")
 
-    if is_ci == False:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+    if cmdData.input_isCI == False:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/mqtt5_pkcs11_connect.py
+++ b/samples/mqtt5_pkcs11_connect.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
 
     print("MQTT5 Client Created")
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/mqtt5_pubsub.py
+++ b/samples/mqtt5_pubsub.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 from awsiot import mqtt5_client_builder
-from awscrt import mqtt5
+from awscrt import mqtt5, http
 import threading
 from concurrent.futures import Future
 import time
@@ -61,10 +61,10 @@ if __name__ == '__main__':
 
     # Create the proxy options if the data is present in cmdData
     proxy_options = None
-    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+    if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=cmdData.input_proxyHost,
-            port=cmdData.input_proxyPort)
+            host_name=cmdData.input_proxy_host,
+            port=cmdData.input_proxy_port)
 
     # Create MQTT5 client
     mqtt5_client = mqtt5_client_builder.mtls_from_path(
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         client_id=cmdData.input_clientId)
     print("MQTT5 Client Created")
 
-    if cmdData.input_isCI == False:
+    if not cmdData.input_isCI:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
@@ -90,8 +90,9 @@ if __name__ == '__main__':
     lifecycle_connect_success_data = future_connection_success.result(TIMEOUT)
     connack_packet = lifecycle_connect_success_data.connack_packet
     negotiated_settings = lifecycle_connect_success_data.negotiated_settings
-    if cmdData.input_isCI == False:
-        print(f"Connected to endpoint:'{cmdData.input_endpoint}' with Client ID:'{cmdData.input_clientId}' with reason_code:{repr(connack_packet.reason_code)}")
+    if not cmdData.input_isCI:
+        print(
+            f"Connected to endpoint:'{cmdData.input_endpoint}' with Client ID:'{cmdData.input_clientId}' with reason_code:{repr(connack_packet.reason_code)}")
 
     # Subscribe
 

--- a/samples/mqtt5_pubsub.py
+++ b/samples/mqtt5_pubsub.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
             port=cmdData.input_proxy_port)
 
     # Create MQTT5 client
-    mqtt5_client = mqtt5_client_builder.mtls_from_path(
+    client = mqtt5_client_builder.mtls_from_path(
         endpoint=cmdData.input_endpoint,
         port=cmdData.input_port,
         cert_filepath=cmdData.input_cert,

--- a/samples/mqtt5_pubsub.py
+++ b/samples/mqtt5_pubsub.py
@@ -1,50 +1,26 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
+from awsiot import mqtt5_client_builder
 from awscrt import mqtt5
-from uuid import uuid4
 import threading
 from concurrent.futures import Future
 import time
 import json
+from utils.command_line_utils import CommandLineUtils
 
 TIMEOUT = 100
 topic_filter = "test/topic"
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("PubSub - Send and receive messages through an MQTT5 connection.")
-cmdUtils.add_common_mqtt5_commands()
-cmdUtils.add_common_topic_message_commands()
-cmdUtils.add_common_proxy_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("key", "<path>", "Path to your key in PEM format.", True, str)
-cmdUtils.register_command("cert", "<path>", "Path to your client certificate in PEM format.", True, str)
-cmdUtils.register_command(
-    "port",
-    "<int>",
-    "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
-    type=int)
-cmdUtils.register_command(
-    "client_id",
-    "<str>",
-    "Client ID to use for MQTT5 connection (optional, default=None).",
-    default="test-" + str(uuid4()))
-cmdUtils.register_command(
-    "count",
-    "<int>",
-    "The number of messages to send (optional, default='10').",
-    default=10,
-    type=int)
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_mqtt5_pubsub()
 
 received_count = 0
 received_all_event = threading.Event()
 future_stopped = Future()
 future_connection_success = Future()
-is_ci = cmdUtils.get_command("is_ci", None) != None
 
 # Callback when any publish is received
 def on_publish_received(publish_packet_data):
@@ -53,7 +29,7 @@ def on_publish_received(publish_packet_data):
     print("Received message from topic'{}':{}".format(publish_packet.topic, publish_packet.payload))
     global received_count
     received_count += 1
-    if received_count == cmdUtils.get_command("count"):
+    if received_count == cmdData.input_count:
         received_all_event.set()
 
 
@@ -79,20 +55,34 @@ def on_lifecycle_connection_failure(lifecycle_connection_failure: mqtt5.Lifecycl
 
 if __name__ == '__main__':
     print("\nStarting MQTT5 PubSub Sample\n")
-    message_count = cmdUtils.get_command("count")
-    message_topic = cmdUtils.get_command(cmdUtils.m_cmd_topic)
-    message_string = cmdUtils.get_command(cmdUtils.m_cmd_message)
+    message_count = cmdData.input_count
+    message_topic = cmdData.input_topic
+    message_string = cmdData.input_message
 
-    client = cmdUtils.build_mqtt5_client(
+    # Create the proxy options if the data is present in cmdData
+    proxy_options = None
+    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+        proxy_options = http.HttpProxyOptions(
+            host_name=cmdData.input_proxyHost,
+            port=cmdData.input_proxyPort)
+
+    # Create MQTT5 client
+    mqtt5_client = mqtt5_client_builder.mtls_from_path(
+        endpoint=cmdData.input_endpoint,
+        port=cmdData.input_port,
+        cert_filepath=cmdData.input_cert,
+        pri_key_filepath=cmdData.input_key,
+        ca_filepath=cmdData.input_ca,
+        http_proxy_options=proxy_options,
         on_publish_received=on_publish_received,
         on_lifecycle_stopped=on_lifecycle_stopped,
         on_lifecycle_connection_success=on_lifecycle_connection_success,
-        on_lifecycle_connection_failure=on_lifecycle_connection_failure)
+        on_lifecycle_connection_failure=on_lifecycle_connection_failure,
+        client_id=cmdData.input_clientId)
     print("MQTT5 Client Created")
 
-    if is_ci == False:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+    if cmdData.input_isCI == False:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 
@@ -100,11 +90,8 @@ if __name__ == '__main__':
     lifecycle_connect_success_data = future_connection_success.result(TIMEOUT)
     connack_packet = lifecycle_connect_success_data.connack_packet
     negotiated_settings = lifecycle_connect_success_data.negotiated_settings
-    if is_ci == False:
-        print("Connected to endpoint:'{}' with Client ID:'{}' with reason_code:{}".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint),
-            connack_packet.assigned_client_identifier,
-            repr(connack_packet.reason_code)))
+    if cmdData.input_isCI == False:
+        print(f"Connected to endpoint:'{cmdData.input_endpoint}' with Client ID:'{cmdData.input_clientId}' with reason_code:{repr(connack_packet.reason_code)}")
 
     # Subscribe
 

--- a/samples/mqtt5_pubsub.py
+++ b/samples/mqtt5_pubsub.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         client_id=cmdData.input_clientId)
     print("MQTT5 Client Created")
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
@@ -90,7 +90,7 @@ if __name__ == '__main__':
     lifecycle_connect_success_data = future_connection_success.result(TIMEOUT)
     connack_packet = lifecycle_connect_success_data.connack_packet
     negotiated_settings = lifecycle_connect_success_data.negotiated_settings
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(
             f"Connected to endpoint:'{cmdData.input_endpoint}' with Client ID:'{cmdData.input_clientId}' with reason_code:{repr(connack_packet.reason_code)}")
 

--- a/samples/mqtt5_shared_subscription.py
+++ b/samples/mqtt5_shared_subscription.py
@@ -8,6 +8,7 @@ import threading
 from concurrent.futures import Future
 import time
 import json
+from utils.command_line_utils import CommandLineUtils
 
 # For the purposes of this sample, we need to associate certain variables with a particular MQTT5 client
 # and to do so we use this class to hold all the data for a particular client used in the sample.
@@ -89,78 +90,34 @@ class sample_mqtt5_client:
                 # Stop the client, which will interrupt the subscription and stop the sample
                 self.client.stop()
 
-# Register arguments that can be parsed from the command line
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("SharedSubscription - Send and receive messages through a MQTT5 shared subscription")
-cmdUtils.add_common_mqtt5_commands()
-cmdUtils.add_common_topic_message_commands()
-cmdUtils.add_common_proxy_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("key", "<path>", "Path to your key in PEM format.", True, str)
-cmdUtils.register_command("cert", "<path>", "Path to your client certificate in PEM format.", True, str)
-cmdUtils.register_command(
-    "port",
-    "<int>",
-    "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
-    type=int)
-cmdUtils.register_command(
-    "client_id",
-    "<str>",
-    "Client ID to use for MQTT5 connection (optional, default=None)."
-    "Note that '1', '2', and '3' will be added for to the given clientIDs since this sample uses 3 clients.",
-    default="test-" + str(uuid4()))
-cmdUtils.register_command(
-    "count",
-    "<int>",
-    "The number of messages to send (optional, default='10').",
-    default=10,
-    type=int)
-cmdUtils.register_command(
-    "group_identifier",
-    "<str>",
-    "The group identifier to use in the shared subscription (optional, default='python-sample')",
-    default="python-sample",
-    type=str)
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
-
-# Pull all the data from the command line
-input_endpoint = cmdUtils.get_command_required("endpoint")
-input_cert = cmdUtils.get_command_required("cert")
-input_key = cmdUtils.get_command_required("key")
-input_ca = cmdUtils.get_command("ca_file")
-input_client_id = cmdUtils.get_command("client_id", "test-" + str(uuid4()))
-input_count = cmdUtils.get_command("count", 10)
-input_topic = cmdUtils.get_command("topic", "test/topic")
-input_message = cmdUtils.get_command("message", "Hello World!")
-input_group_identifier = cmdUtils.get_command("group_identifier", "python-sample")
-input_is_ci = cmdUtils.get_command("is_ci", None)
-input_is_ci_boolean = (input_is_ci != None and input_is_ci != "None")
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_mqtt5_shared_subscription()
 
 # If this is CI, append a UUID to the topic
-if (input_is_ci_boolean):
-    input_topic += "/" + str(uuid4())
+if (cmdData.input_isCI):
+    cmdData.input_topic += "/" + str(uuid4())
 
 # Construct the shared topic
-input_shared_topic = f"$share/{input_group_identifier}/{input_topic}"
+input_shared_topic = f"$share/{cmdData.input_groupIdentifier}/{cmdData.input_topic}"
 
 # Make sure the message count is even
-if (input_count % 2 > 0):
+if (cmdData.input_count % 2 > 0):
     exit(ValueError("Error: '--count' is an odd number. '--count' must be even or zero for this sample."))
 
 if __name__ == '__main__':
     try:
         # Create the MQTT5 clients: one publisher and two subscribers
         publisher = sample_mqtt5_client(
-            input_endpoint, input_cert, input_key, input_ca,
-            input_client_id + "1", input_count/2, "Publisher")
+            cmdData.input_endpoint, cmdData.input_cert, cmdData.input_key, cmdData.input_ca,
+            cmdData.input_clientId + "1", cmdData.input_count/2, "Publisher")
         subscriber_one = sample_mqtt5_client(
-            input_endpoint, input_cert, input_key, input_ca,
-            input_client_id + "2", input_count/2, "Subscriber One")
+            cmdData.input_endpoint, cmdData.input_cert, cmdData.input_key, cmdData.input_ca,
+            cmdData.input_clientId + "2", cmdData.input_count/2, "Subscriber One")
         subscriber_two = sample_mqtt5_client(
-            input_endpoint, input_cert, input_key, input_ca,
-            input_client_id + "3", input_count, "Subscriber Two")
+            cmdData.input_endpoint, cmdData.input_cert, cmdData.input_key, cmdData.input_ca,
+            cmdData.input_clientId + "3", cmdData.input_count, "Subscriber Two")
 
         # Connect all the clients
         publisher.client.start()
@@ -188,18 +145,18 @@ if __name__ == '__main__':
             print(f"[{subscriber_two.name}]: Subscribed with: {suback_two.reason_codes}")
         except Exception as ex:
             # TMP: If this fails subscribing in CI, just exit the sample gracefully.
-            if (input_is_ci != None and input_is_ci != "None"):
+            if (cmdData.input_isCI != None and cmdData.input_isCI != "None"):
                 exit(0)
             else:
                 raise ex
 
         # Publish using the publisher client
-        if (input_count > 0):
+        if (cmdData.input_count > 0):
             publish_count = 1
-            while (publish_count <= input_count):
-                publish_message = f"{input_message} [{publish_count}]"
+            while (publish_count <= cmdData.input_count):
+                publish_message = f"{cmdData.input_message} [{publish_count}]"
                 publish_future = publisher.client.publish(mqtt5.PublishPacket(
-                    topic=input_topic,
+                    topic=cmdData.input_topic,
                     payload=json.dumps(publish_message),
                     qos=mqtt5.QoS.AT_LEAST_ONCE
                 ))

--- a/samples/mqtt5_shared_subscription.py
+++ b/samples/mqtt5_shared_subscription.py
@@ -13,16 +13,24 @@ from utils.command_line_utils import CommandLineUtils
 # For the purposes of this sample, we need to associate certain variables with a particular MQTT5 client
 # and to do so we use this class to hold all the data for a particular client used in the sample.
 class sample_mqtt5_client:
-    client : mqtt5.Client
-    name : str
-    count : int
-    received_count : int
+    client: mqtt5.Client
+    name: str
+    count: int
+    received_count: int
     received_all_event = threading.Event()
-    future_stopped : Future
-    future_connection_success : Future
+    future_stopped: Future
+    future_connection_success: Future
 
     # Creates a MQTT5 client using direct MQTT5 via mTLS with the passed input data.
-    def __init__(self, input_endpoint, input_cert, input_key, input_ca, input_client_id, input_count, input_client_name) -> None:
+    def __init__(
+            self,
+            input_endpoint,
+            input_cert,
+            input_key,
+            input_ca,
+            input_client_id,
+            input_count,
+            input_client_name) -> None:
         try:
             self.count = input_count
             self.received_count = 0
@@ -42,7 +50,7 @@ class sample_mqtt5_client:
                 on_lifecycle_disconnection=self.on_lifecycle_disconnection,
             )
         except Exception as ex:
-            print (f"Client creation failed with exception: {ex}")
+            print(f"Client creation failed with exception: {ex}")
             raise ex
 
     # Callback when any publish is received
@@ -54,7 +62,7 @@ class sample_mqtt5_client:
         print(f"\tPublish received message on topic: {publish_packet.topic}")
         print(f"\tMessage: {publish_packet.payload}")
 
-        if (publish_packet.user_properties != None):
+        if (publish_packet.user_properties is not None):
             if (publish_packet.user_properties.count > 0):
                 for i in range(0, publish_packet.user_properties.count):
                     user_property = publish_packet.user_properties[i]
@@ -83,24 +91,22 @@ class sample_mqtt5_client:
     def on_lifecycle_disconnection(self, disconnect_data: mqtt5.LifecycleDisconnectData):
         print(f"{self.name}]: Lifecycle Disconnected")
 
-        if (disconnect_data.disconnect_packet != None):
+        if (disconnect_data.disconnect_packet is not None):
             print(f"\tDisconnection packet code: {disconnect_data.disconnect_packet.reason_code}")
             print(f"\tDisconnection packet reason: {disconnect_data.disconnect_packet.reason_string}")
-            if (disconnect_data.disconnect_packet.reason_code == mqtt5.DisconnectReasonCode.SHARED_SUBSCRIPTIONS_NOT_SUPPORTED):
+            if (disconnect_data.disconnect_packet.reason_code ==
+                    mqtt5.DisconnectReasonCode.SHARED_SUBSCRIPTIONS_NOT_SUPPORTED):
                 # Stop the client, which will interrupt the subscription and stop the sample
                 self.client.stop()
+
 
 # cmdData is the arguments/input from the command line placed into a single struct for
 # use in this sample. This handles all of the command line parsing, validating, etc.
 # See the Utils/CommandLineUtils for more information.
 cmdData = CommandLineUtils.parse_sample_input_mqtt5_shared_subscription()
 
-# If this is CI, append a UUID to the topic
-if (cmdData.input_isCI):
-    cmdData.input_topic += "/" + str(uuid4())
-
 # Construct the shared topic
-input_shared_topic = f"$share/{cmdData.input_groupIdentifier}/{cmdData.input_topic}"
+input_shared_topic = f"$share/{cmdData.input_group_identifier}/{cmdData.input_topic}"
 
 # Make sure the message count is even
 if (cmdData.input_count % 2 > 0):
@@ -111,10 +117,10 @@ if __name__ == '__main__':
         # Create the MQTT5 clients: one publisher and two subscribers
         publisher = sample_mqtt5_client(
             cmdData.input_endpoint, cmdData.input_cert, cmdData.input_key, cmdData.input_ca,
-            cmdData.input_clientId + "1", cmdData.input_count/2, "Publisher")
+            cmdData.input_clientId + "1", cmdData.input_count / 2, "Publisher")
         subscriber_one = sample_mqtt5_client(
             cmdData.input_endpoint, cmdData.input_cert, cmdData.input_key, cmdData.input_ca,
-            cmdData.input_clientId + "2", cmdData.input_count/2, "Subscriber One")
+            cmdData.input_clientId + "2", cmdData.input_count / 2, "Subscriber One")
         subscriber_two = sample_mqtt5_client(
             cmdData.input_endpoint, cmdData.input_cert, cmdData.input_key, cmdData.input_ca,
             cmdData.input_clientId + "3", cmdData.input_count, "Subscriber Two")
@@ -122,13 +128,13 @@ if __name__ == '__main__':
         # Connect all the clients
         publisher.client.start()
         publisher.future_connection_success.result(60)
-        print (f"[{publisher.name}]: Connected")
+        print(f"[{publisher.name}]: Connected")
         subscriber_one.client.start()
         subscriber_one.future_connection_success.result(60)
-        print (f"[{subscriber_one.name}]: Connected")
+        print(f"[{subscriber_one.name}]: Connected")
         subscriber_two.client.start()
         subscriber_two.future_connection_success.result(60)
-        print (f"[{subscriber_two.name}]: Connected")
+        print(f"[{subscriber_two.name}]: Connected")
 
         # Subscribe to the shared topic on the two subscribers
         subscribe_packet = mqtt5.SubscribePacket(
@@ -145,7 +151,7 @@ if __name__ == '__main__':
             print(f"[{subscriber_two.name}]: Subscribed with: {suback_two.reason_codes}")
         except Exception as ex:
             # TMP: If this fails subscribing in CI, just exit the sample gracefully.
-            if (cmdData.input_isCI != None and cmdData.input_isCI != "None"):
+            if (cmdData.input_isCI is not None and cmdData.input_isCI != "None"):
                 exit(0)
             else:
                 raise ex
@@ -192,7 +198,7 @@ if __name__ == '__main__':
         print(f"[{subscriber_two.name}]: Fully stopped")
 
     except Exception as ex:
-        print (f"An exception ocurred while running sample! Exception: {ex}")
+        print(f"An exception ocurred while running sample! Exception: {ex}")
         exit(ex)
 
-    print ("Complete!")
+    print("Complete!")

--- a/samples/mqtt5_shared_subscription.py
+++ b/samples/mqtt5_shared_subscription.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
             print(f"[{subscriber_two.name}]: Subscribed with: {suback_two.reason_codes}")
         except Exception as ex:
             # TMP: If this fails subscribing in CI, just exit the sample gracefully.
-            if (cmdData.input_isCI is not None and cmdData.input_isCI != "None"):
+            if (cmdData.input_is_ci is not None):
                 exit(0)
             else:
                 raise ex

--- a/samples/pkcs11_connect.py
+++ b/samples/pkcs11_connect.py
@@ -17,7 +17,7 @@ from utils.command_line_utils import CommandLineUtils
 # cmdData is the arguments/input from the command line placed into a single struct for
 # use in this sample. This handles all of the command line parsing, validating, etc.
 # See the Utils/CommandLineUtils for more information.
-cmdData = CommandLineUtils.parse_sample_input_mqtt5_pkcs11_connect()
+cmdData = CommandLineUtils.parse_sample_input_pkcs11_connect()
 
 # Callback when connection is accidentally lost.
 def on_connection_interrupted(connection, error, **kwargs):

--- a/samples/pkcs11_connect.py
+++ b/samples/pkcs11_connect.py
@@ -30,23 +30,23 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 
 if __name__ == '__main__':
 
-    print(f"Loading PKCS#11 library '{cmdData.input_pkcs11LibPath}' ...")
+    print(f"Loading PKCS#11 library '{cmdData.input_pkcs11_lib_path}' ...")
     pkcs11_lib = io.Pkcs11Lib(
-        file=cmdData.input_pkcs11LibPath,
+        file=cmdData.input_pkcs11_lib_path,
         behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
     print("Loaded!")
 
     pkcs11_slot_id = None
-    if (cmdData.input_pkcs11SlotId):
-        pkcs11_slot_id = int(cmdData.input_pkcs11SlotId)
+    if (cmdData.input_pkcs11_slot_id):
+        pkcs11_slot_id = int(cmdData.input_pkcs11_slot_id)
 
     # Create MQTT connection
     mqtt_connection = mqtt_connection_builder.mtls_with_pkcs11(
         pkcs11_lib=pkcs11_lib,
-        user_pin=cmdData.input_pkcs11UserPin,
+        user_pin=cmdData.input_pkcs11_user_pin,
         slot_id=pkcs11_slot_id,
-        token_label=cmdData.input_pkcs11TokenLabel,
-        private_key_label=cmdData.input_pkcs11KeyLabel,
+        token_label=cmdData.input_pkcs11_token_label,
+        private_key_label=cmdData.input_pkcs11_key_label,
         cert_filepath=cmdData.input_cert,
         endpoint=cmdData.input_endpoint,
         port=cmdData.input_port,
@@ -57,7 +57,7 @@ if __name__ == '__main__':
         clean_session=False,
         keep_alive_secs=30)
 
-    if cmdData.input_isCI == False:
+    if not cmdData.input_isCI:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/pkcs11_connect.py
+++ b/samples/pkcs11_connect.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
         clean_session=False,
         keep_alive_secs=30)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -42,12 +42,12 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 
 
 def on_resubscribe_complete(resubscribe_future):
-        resubscribe_results = resubscribe_future.result()
-        print("Resubscribe results: {}".format(resubscribe_results))
+    resubscribe_results = resubscribe_future.result()
+    print("Resubscribe results: {}".format(resubscribe_results))
 
-        for topic, qos in resubscribe_results['topics']:
-            if qos is None:
-                sys.exit("Server rejected resubscribe to topic: {}".format(topic))
+    for topic, qos in resubscribe_results['topics']:
+        if qos is None:
+            sys.exit("Server rejected resubscribe to topic: {}".format(topic))
 
 
 # Callback when the subscribed topic receives a message
@@ -58,13 +58,14 @@ def on_message_received(topic, payload, dup, qos, retain, **kwargs):
     if received_count == cmdData.input_count:
         received_all_event.set()
 
+
 if __name__ == '__main__':
     # Create the proxy options if the data is present in cmdData
     proxy_options = None
-    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+    if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=cmdData.input_proxyHost,
-            port=cmdData.input_proxyPort)
+            host_name=cmdData.input_proxy_host,
+            port=cmdData.input_proxy_port)
 
     # Create a MQTT connection from the command line data
     mqtt_connection = mqtt_connection_builder.mtls_from_path(
@@ -80,7 +81,7 @@ if __name__ == '__main__':
         keep_alive_secs=30,
         http_proxy_options=proxy_options)
 
-    if cmdData.input_isCI == False:
+    if not cmdData.input_isCI:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
@@ -109,9 +110,9 @@ if __name__ == '__main__':
     # This step loops forever if count was set to 0.
     if message_string:
         if message_count == 0:
-            print ("Sending messages until program killed")
+            print("Sending messages until program killed")
         else:
-            print ("Sending {} message(s)".format(message_count))
+            print("Sending {} message(s)".format(message_count))
 
         publish_count = 1
         while (publish_count <= message_count) or (message_count == 0):

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -18,7 +18,7 @@ from utils.command_line_utils import CommandLineUtils
 # cmdData is the arguments/input from the command line placed into a single struct for
 # use in this sample. This handles all of the command line parsing, validating, etc.
 # See the Utils/CommandLineUtils for more information.
-cmdData = CommandLineUtils.parse_sample_input_mqtt5_pkcs11_connect()
+cmdData = CommandLineUtils.parse_sample_input_pubsub()
 
 received_count = 0
 received_all_event = threading.Event()

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         keep_alive_secs=30,
         http_proxy_options=proxy_options)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -279,7 +279,7 @@ def change_shadow_value(value):
 
 def user_input_thread_fn():
     # If we are not in CI, then take terminal input
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         while True:
             try:
                 # Read user input
@@ -332,7 +332,7 @@ if __name__ == '__main__':
         keep_alive_secs=30,
         http_proxy_options=proxy_options)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -719,7 +719,6 @@ class CommandLineUtils:
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
         cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
-        cmdData.input_cognitoIdentity = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cognito_identity)
         cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
@@ -817,6 +816,42 @@ class CommandLineUtils:
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
         cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
         cmdData.input_groupIdentifier = cmdUtils.get_command(CommandLineUtils.m_cmd_group_identifier, "python-sample")
+        return cmdData
+
+    def parse_sample_input_pkcs11_connect():
+        cmdUtils = CommandLineUtils("PKCS11 Connect - Make a MQTT connection using PKCS11.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_cert_file, "<path>", "Path to your client certificate in PEM format.", True, str)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
+                                "Client ID to use for MQTT connection (optional, default='test-*').",
+                                default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<port>",
+                                "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).",
+                                type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_lib, "<path>", "Path to PKCS#11 Library", required=True)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_pin, "<str>", "User PIN for logging into PKCS#11 token.", required=True)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_token, "<str>", "Label of the PKCS#11 token to use (optional).")
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_slot, "<int>", "Slot ID containing the PKCS#11 token to use (optional).", False, int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_key, "<str>", "Label of private key on the PKCS#11 token (optional).")
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, None))
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_pkcs11LibPath = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
+        cmdData.input_pkcs11UserPin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
+        cmdData.input_pkcs11TokenLabel = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_token)
+        cmdData.input_pkcs11SlotId = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
+        cmdData.input_pkcs11KeyLabel = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -479,6 +479,8 @@ class CommandLineUtils:
         # Basic discovery
         input_maxPubOps : int
         input_printDiscoveryRespOnly : bool
+        # Jobs
+        input_jobTime : int
 
         def __init__(self) -> None:
             pass
@@ -631,6 +633,33 @@ class CommandLineUtils:
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
+    def parse_sample_input_jobs():
+        cmdUtils = CommandLineUtils("Jobs - Receive and execute operations on the device.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_key_cert_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_thing_name, "<str>", "The name assigned to your IoT Thing", required=True)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_job_time, "<int>", "Emulate working on a job by sleeping this many seconds (optional, default='5')", default=5, type=int)
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_csrPath = cmdUtils.get_command(CommandLineUtils.m_cmd_csr, None)
+        cmdData.input_thingName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
+        cmdData.input_jobTime = int(cmdUtils.get_command(CommandLineUtils.m_cmd_job_time, 5))
+        return cmdData
+
 
     # Constants for commonly used/needed commands
     m_cmd_endpoint = "endpoint"
@@ -670,3 +699,4 @@ class CommandLineUtils:
     m_cmd_csr = "csr"
     m_cmd_template_name = "template_name"
     m_cmd_template_parameters = "template_parameters"
+    m_cmd_job_time = "job_time"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -511,11 +511,11 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_pkcs11_lib_path = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
         cmdData.input_pkcs11_user_pin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
@@ -633,11 +633,11 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_pkcs11_lib_path = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
         cmdData.input_pkcs11_user_pin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
@@ -739,6 +739,7 @@ class CommandLineUtils:
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -769,6 +769,7 @@ class CommandLineUtils:
         cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
         cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+        cmdData.input_count = int(cmdUtils.get_command(CommandLineUtils.m_cmd_count, 10))
         return cmdData
 
     def parse_sample_input_mqtt5_shared_subscription():
@@ -852,6 +853,33 @@ class CommandLineUtils:
         cmdData.input_pkcs11SlotId = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
         cmdData.input_pkcs11KeyLabel = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
+    def parse_sample_input_pubsub():
+        cmdUtils = CommandLineUtils("PubSub - Send and receive messages through an MQTT connection.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_topic_message_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_key_cert_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_count, "<int>", "The number of messages to send (optional, default='10').", default=10, type=int)
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
+        cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+        cmdData.input_count = int(cmdUtils.get_command(CommandLineUtils.m_cmd_count, 10))
         return cmdData
 
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -781,7 +781,7 @@ class CommandLineUtils:
     m_cmd_key_file = "key"
     m_cmd_proxy_host = "proxy_host"
     m_cmd_proxy_port = "proxy_port"
-    m_cmd_signing_region = "region"
+    m_cmd_signing_region = "signing_region"
     m_cmd_pkcs11_lib = "pkcs11_lib"
     m_cmd_pkcs11_cert = "cert"
     m_cmd_pkcs11_pin = "pin"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -27,6 +27,29 @@ class CommandLineUtils:
         if command_name in self.commands.keys():
             self.commands.pop(command_name)
 
+    """
+    Returns the command if it exists and has been passed to the console, otherwise it will print the help for the sample and exit the application.
+    """
+    def get_command_required(self, command_name, message=None):
+        if hasattr(self.parsed_commands, command_name):
+            return getattr(self.parsed_commands, command_name)
+        else:
+            self.parser.print_help()
+            print("Command --" + command_name + " required.")
+            if message is not None:
+                print(message)
+            exit()
+
+    """
+    Returns the command if it exists, has been passed to the console, and is not None. Otherwise it returns whatever is passed as the default.
+    """
+    def get_command(self, command_name, default=None):
+        if hasattr(self.parsed_commands, command_name):
+            result = getattr(self.parsed_commands, command_name)
+            if (result != None):
+                return result
+        return default
+
     def get_args(self):
         # if we have already parsed, then return the cached parsed commands
         if self.parsed_commands is not None:
@@ -192,27 +215,6 @@ class CommandLineUtils:
             "Path to the root certificate used in fetching x509 credentials"
         )
 
-    """
-    Returns the command if it exists and has been passed to the console, otherwise it will print the help for the sample and exit the application.
-    """
-    def get_command_required(self, command_name, message=None):
-        if hasattr(self.parsed_commands, command_name):
-            return getattr(self.parsed_commands, command_name)
-        else:
-            self.parser.print_help()
-            print("Command --" + command_name + " required.")
-            if message is not None:
-                print(message)
-            exit()
-
-    """
-    Returns the command if it exists and has been passed to the console, otherwise it returns whatever is passed as the default.
-    """
-    def get_command(self, command_name, default=None):
-        if hasattr(self.parsed_commands, command_name):
-            return getattr(self.parsed_commands, command_name)
-        return default
-
     ########################################################################
     # cmdData utils/functions
     ########################################################################
@@ -300,7 +302,7 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
@@ -410,7 +412,7 @@ class CommandLineUtils:
         cmdUtils.add_common_logging_commands()
         cmdUtils.add_common_key_cert_commands()
         cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
-        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=8883).", type=int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_csr, "<path>", "Path to CSR in Pem format (optional).")
         cmdUtils.register_command(CommandLineUtils.m_cmd_template_name, "<str>", "The name of your provisioning template.")
         cmdUtils.register_command(CommandLineUtils.m_cmd_template_parameters, "<json>", "Template parameters json.")
@@ -418,7 +420,7 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
@@ -438,14 +440,14 @@ class CommandLineUtils:
         cmdUtils.add_common_logging_commands()
         cmdUtils.add_common_key_cert_commands()
         cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
-        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=8883).", type=int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_thing_name, "<str>", "The name assigned to your IoT Thing", required=True)
         cmdUtils.register_command(CommandLineUtils.m_cmd_job_time, "<int>", "Emulate working on a job by sleeping this many seconds (optional, default='5')", default=5, type=int)
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
@@ -492,7 +494,7 @@ class CommandLineUtils:
         cmdUtils.register_command(
             CommandLineUtils.m_cmd_port,
             "<int>",
-            "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
+            "Connection port. AWS IoT supports 433 and 8883 (optional, default=8883).",
             type=int)
         cmdUtils.register_command(
             CommandLineUtils.m_cmd_client_id,
@@ -512,7 +514,7 @@ class CommandLineUtils:
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, None))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_pkcs11_lib_path = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
         cmdData.input_pkcs11_user_pin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
@@ -532,7 +534,7 @@ class CommandLineUtils:
         cmdUtils.register_command(
             CommandLineUtils.m_cmd_port,
             "<int>",
-            "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
+            "Connection port. AWS IoT supports 433 and 8883 (optional, default=8883).",
             type=int)
         cmdUtils.register_command(
             CommandLineUtils.m_cmd_client_id,
@@ -549,7 +551,7 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
@@ -571,7 +573,7 @@ class CommandLineUtils:
         cmdUtils.register_command(
             CommandLineUtils.m_cmd_port,
             "<int>",
-            "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
+            "Connection port. AWS IoT supports 433 and 8883 (optional, default=8883).",
             type=int)
         cmdUtils.register_command(
             CommandLineUtils.m_cmd_client_id,
@@ -595,7 +597,7 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
@@ -617,7 +619,7 @@ class CommandLineUtils:
                                 "Client ID to use for MQTT connection (optional, default='test-*').",
                                 default="test-" + str(uuid4()))
         cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<port>",
-                                "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).",
+                                "Connection port. AWS IoT supports 443 and 8883 (optional, default=8883).",
                                 type=int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_lib, "<path>", "Path to PKCS#11 Library", required=True)
         cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_pin, "<str>", "User PIN for logging into PKCS#11 token.", required=True)
@@ -632,7 +634,7 @@ class CommandLineUtils:
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, None))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_pkcs11_lib_path = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
         cmdData.input_pkcs11_user_pin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
@@ -649,14 +651,14 @@ class CommandLineUtils:
         cmdUtils.add_common_proxy_commands()
         cmdUtils.add_common_logging_commands()
         cmdUtils.add_common_key_cert_commands()
-        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=8883).", type=int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
         cmdUtils.register_command(CommandLineUtils.m_cmd_count, "<int>", "The number of messages to send (optional, default='10').", default=10, type=int)
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
@@ -674,7 +676,7 @@ class CommandLineUtils:
         cmdUtils.add_common_proxy_commands()
         cmdUtils.add_common_logging_commands()
         cmdUtils.add_common_key_cert_commands()
-        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=8883).", type=int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
         cmdUtils.register_command(CommandLineUtils.m_cmd_thing_name, "<str>", "The name assigned to your IoT Thing", required=True)
         cmdUtils.register_command(CommandLineUtils.m_cmd_shadow_property, "<str>", "The name of the shadow property you want to change (optional, default='color'", default="color")
@@ -682,7 +684,7 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, 8883))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -463,8 +463,13 @@ class CommandLineUtils:
         cmdUtils = CommandLineUtils(
             "Custom Authorizer Connect - Make a MQTT5 Client connection using a custom authorizer.")
         cmdUtils.add_common_mqtt_commands()
-        cmdUtils.register_command(CommandLineUtils.m_cmd_key_file, "<path>", "Path to your key in PEM format.", False, str)
-        cmdUtils.register_command(CommandLineUtils.m_cmd_cert_file, "<path>", "Path to your client certificate in PEM format.", False, str)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_key_file, "<path>",
+                                "Path to your key in PEM format.", False, str)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_cert_file, "<path>",
+                                "Path to your client certificate in PEM format.", False, str)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_signing_region, "<str>",
+                                "The signing region used for the websocket signer",
+                                False, str)
         cmdUtils.add_common_logging_commands()
         cmdUtils.add_common_custom_authorizer_commands()
         cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 import argparse
-from awscrt import io, http, auth
-from awsiot import mqtt_connection_builder, mqtt5_client_builder
+from awscrt import io
 from uuid import uuid4
 
 class CommandLineUtils:
@@ -214,220 +213,6 @@ class CommandLineUtils:
             return getattr(self.parsed_commands, command_name)
         return default
 
-    def build_pkcs11_mqtt_connection(self, on_connection_interrupted, on_connection_resumed):
-
-        pkcs11_lib_path = self.get_command_required(self.m_cmd_pkcs11_lib)
-        print(f"Loading PKCS#11 library '{pkcs11_lib_path}' ...")
-        pkcs11_lib = io.Pkcs11Lib(
-            file=pkcs11_lib_path,
-            behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
-        print("Loaded!")
-
-        pkcs11_slot_id = None
-        if (self.get_command(self.m_cmd_pkcs11_slot) != None):
-            pkcs11_slot_id = int(self.get_command(self.m_cmd_pkcs11_slot))
-
-        # Create MQTT connection
-        mqtt_connection = mqtt_connection_builder.mtls_with_pkcs11(
-            pkcs11_lib=pkcs11_lib,
-            user_pin=self.get_command_required(self.m_cmd_pkcs11_pin),
-            slot_id=pkcs11_slot_id,
-            token_label=self.get_command_required(self.m_cmd_pkcs11_token),
-            private_key_label=self.get_command_required(self.m_cmd_pkcs11_key),
-            cert_filepath=self.get_command_required(self.m_cmd_pkcs11_cert),
-            endpoint=self.get_command_required(self.m_cmd_endpoint),
-            port=self.get_command("port"),
-            ca_filepath=self.get_command(self.m_cmd_ca_file),
-            on_connection_interrupted=on_connection_interrupted,
-            on_connection_resumed=on_connection_resumed,
-            client_id=self.get_command_required("client_id"),
-            clean_session=False,
-            keep_alive_secs=30)
-        return mqtt_connection
-
-    def build_websocket_mqtt_connection(self, on_connection_interrupted, on_connection_resumed):
-        proxy_options = self.get_proxy_options_for_mqtt_connection()
-        credentials_provider = auth.AwsCredentialsProvider.new_default_chain()
-        mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
-            endpoint=self.get_command_required(self.m_cmd_endpoint),
-            region=self.get_command_required(self.m_cmd_signing_region),
-            credentials_provider=credentials_provider,
-            http_proxy_options=proxy_options,
-            ca_filepath=self.get_command(self.m_cmd_ca_file),
-            on_connection_interrupted=on_connection_interrupted,
-            on_connection_resumed=on_connection_resumed,
-            client_id=self.get_command_required("client_id"),
-            clean_session=False,
-            keep_alive_secs=30)
-        return mqtt_connection
-
-    def build_cognito_mqtt_connection(self, on_connection_interrupted, on_connection_resumed):
-        proxy_options = self.get_proxy_options_for_mqtt_connection()
-
-        cognito_endpoint = "cognito-identity." + self.get_command_required(self.m_cmd_signing_region) + ".amazonaws.com"
-        credentials_provider = auth.AwsCredentialsProvider.new_cognito(
-            endpoint=cognito_endpoint,
-            identity=self.get_command_required(self.m_cmd_cognito_identity),
-            tls_ctx=io.ClientTlsContext(io.TlsContextOptions()))
-
-        mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
-            endpoint=self.get_command_required(self.m_cmd_endpoint),
-            region=self.get_command_required(self.m_cmd_signing_region),
-            credentials_provider=credentials_provider,
-            http_proxy_options=proxy_options,
-            ca_filepath=self.get_command(self.m_cmd_ca_file),
-            on_connection_interrupted=on_connection_interrupted,
-            on_connection_resumed=on_connection_resumed,
-            client_id=self.get_command_required("client_id"),
-            clean_session=False,
-            keep_alive_secs=30)
-        return mqtt_connection
-
-    def build_direct_mqtt_connection(self, on_connection_interrupted, on_connection_resumed):
-        proxy_options = self.get_proxy_options_for_mqtt_connection()
-        mqtt_connection = mqtt_connection_builder.mtls_from_path(
-            endpoint=self.get_command_required(self.m_cmd_endpoint),
-            port=self.get_command_required("port"),
-            cert_filepath=self.get_command_required(self.m_cmd_cert_file),
-            pri_key_filepath=self.get_command_required(self.m_cmd_key_file),
-            ca_filepath=self.get_command(self.m_cmd_ca_file),
-            on_connection_interrupted=on_connection_interrupted,
-            on_connection_resumed=on_connection_resumed,
-            client_id=self.get_command_required("client_id"),
-            clean_session=False,
-            keep_alive_secs=30,
-            http_proxy_options=proxy_options)
-        return mqtt_connection
-
-    def build_mqtt_connection(self, on_connection_interrupted, on_connection_resumed):
-        if self.get_command(self.m_cmd_signing_region) is not None:
-            return self.build_websocket_mqtt_connection(on_connection_interrupted, on_connection_resumed)
-        else:
-            return self.build_direct_mqtt_connection(on_connection_interrupted, on_connection_resumed)
-
-    def get_proxy_options_for_mqtt_connection(self):
-        proxy_options = None
-        if self.parsed_commands.proxy_host and self.parsed_commands.proxy_port:
-            proxy_options = http.HttpProxyOptions(
-                host_name=self.parsed_commands.proxy_host,
-                port=self.parsed_commands.proxy_port)
-        return proxy_options
-
-    ########################################################################
-    # MQTT5
-    ########################################################################
-
-    def build_pkcs11_mqtt5_client(self,
-                                  on_publish_received=None,
-                                  on_lifecycle_stopped=None,
-                                  on_lifecycle_attempting_connect=None,
-                                  on_lifecycle_connection_success=None,
-                                  on_lifecycle_connection_failure=None,
-                                  on_lifecycle_disconnection=None):
-
-        pkcs11_lib_path = self.get_command_required(self.m_cmd_pkcs11_lib)
-        print(f"Loading PKCS#11 library '{pkcs11_lib_path}' ...")
-        pkcs11_lib = io.Pkcs11Lib(
-            file=pkcs11_lib_path,
-            behavior=io.Pkcs11Lib.InitializeFinalizeBehavior.STRICT)
-        print("Loaded!")
-
-        pkcs11_slot_id = None
-        if (self.get_command(self.m_cmd_pkcs11_slot) is not None):
-            pkcs11_slot_id = int(self.get_command(self.m_cmd_pkcs11_slot))
-
-        # Create MQTT5 client
-        mqtt5_client = mqtt5_client_builder.mtls_with_pkcs11(
-            pkcs11_lib=pkcs11_lib,
-            user_pin=self.get_command_required(self.m_cmd_pkcs11_pin),
-            slot_id=pkcs11_slot_id,
-            token_label=self.get_command_required(self.m_cmd_pkcs11_token),
-            private_key_label=self.get_command_required(self.m_cmd_pkcs11_key),
-            cert_filepath=self.get_command_required(self.m_cmd_pkcs11_cert),
-            endpoint=self.get_command_required(self.m_cmd_endpoint),
-            port=self.get_command("port"),
-            ca_filepath=self.get_command(self.m_cmd_ca_file),
-            on_publish_received=on_publish_received,
-            on_lifecycle_stopped=on_lifecycle_stopped,
-            on_lifecycle_attempting_connect=on_lifecycle_attempting_connect,
-            on_lifecycle_connection_success=on_lifecycle_connection_success,
-            on_lifecycle_connection_failure=on_lifecycle_connection_failure,
-            on_lifecycle_disconnection=on_lifecycle_disconnection,
-            client_id=self.get_command("client_id"))
-
-        return mqtt5_client
-
-    def build_websocket_mqtt5_client(self,
-                                     on_publish_received=None,
-                                     on_lifecycle_stopped=None,
-                                     on_lifecycle_attempting_connect=None,
-                                     on_lifecycle_connection_success=None,
-                                     on_lifecycle_connection_failure=None,
-                                     on_lifecycle_disconnection=None):
-        proxy_options = self.get_proxy_options_for_mqtt_connection()
-        credentials_provider = auth.AwsCredentialsProvider.new_default_chain()
-        mqtt5_client = mqtt5_client_builder.websockets_with_default_aws_signing(
-            endpoint=self.get_command_required(self.m_cmd_endpoint),
-            region=self.get_command_required(self.m_cmd_signing_region),
-            credentials_provider=credentials_provider,
-            http_proxy_options=proxy_options,
-            ca_filepath=self.get_command(self.m_cmd_ca_file),
-            on_publish_received=on_publish_received,
-            on_lifecycle_stopped=on_lifecycle_stopped,
-            on_lifecycle_attempting_connect=on_lifecycle_attempting_connect,
-            on_lifecycle_connection_success=on_lifecycle_connection_success,
-            on_lifecycle_connection_failure=on_lifecycle_connection_failure,
-            on_lifecycle_disconnection=on_lifecycle_disconnection,
-            client_id=self.get_command_required("client_id"))
-        return mqtt5_client
-
-    def build_direct_mqtt5_client(self,
-                                  on_publish_received=None,
-                                  on_lifecycle_stopped=None,
-                                  on_lifecycle_attempting_connect=None,
-                                  on_lifecycle_connection_success=None,
-                                  on_lifecycle_connection_failure=None,
-                                  on_lifecycle_disconnection=None):
-        proxy_options = self.get_proxy_options_for_mqtt_connection()
-        mqtt5_client = mqtt5_client_builder.mtls_from_path(
-            endpoint=self.get_command_required(self.m_cmd_endpoint),
-            port=self.get_command_required("port"),
-            cert_filepath=self.get_command_required(self.m_cmd_cert_file),
-            pri_key_filepath=self.get_command_required(self.m_cmd_key_file),
-            ca_filepath=self.get_command(self.m_cmd_ca_file),
-            http_proxy_options=proxy_options,
-            on_publish_received=on_publish_received,
-            on_lifecycle_stopped=on_lifecycle_stopped,
-            on_lifecycle_attempting_connect=on_lifecycle_attempting_connect,
-            on_lifecycle_connection_success=on_lifecycle_connection_success,
-            on_lifecycle_connection_failure=on_lifecycle_connection_failure,
-            on_lifecycle_disconnection=on_lifecycle_disconnection,
-            client_id=self.get_command_required("client_id"))
-        return mqtt5_client
-
-    def build_mqtt5_client(self,
-                           on_publish_received=None,
-                           on_lifecycle_stopped=None,
-                           on_lifecycle_attempting_connect=None,
-                           on_lifecycle_connection_success=None,
-                           on_lifecycle_connection_failure=None,
-                           on_lifecycle_disconnection=None):
-
-        if self.get_command(self.m_cmd_signing_region) is not None:
-            return self.build_websocket_mqtt5_client(on_publish_received=on_publish_received,
-                                                     on_lifecycle_stopped=on_lifecycle_stopped,
-                                                     on_lifecycle_attempting_connect=on_lifecycle_attempting_connect,
-                                                     on_lifecycle_connection_success=on_lifecycle_connection_success,
-                                                     on_lifecycle_connection_failure=on_lifecycle_connection_failure,
-                                                     on_lifecycle_disconnection=on_lifecycle_disconnection)
-        else:
-            return self.build_direct_mqtt5_client(on_publish_received=on_publish_received,
-                                                  on_lifecycle_stopped=on_lifecycle_stopped,
-                                                  on_lifecycle_attempting_connect=on_lifecycle_attempting_connect,
-                                                  on_lifecycle_connection_success=on_lifecycle_connection_success,
-                                                  on_lifecycle_connection_failure=on_lifecycle_connection_failure,
-                                                  on_lifecycle_disconnection=on_lifecycle_disconnection)
-
     ########################################################################
     # cmdData utils/functions
     ########################################################################
@@ -441,58 +226,60 @@ class CommandLineUtils:
         input_clientId : str
         input_port : int
         input_isCI : bool
-        input_useWebsockets : bool
+        input_use_websockets : bool
         # Proxy
-        input_proxyHost : str
-        input_proxyPort : int
+        input_proxy_host : str
+        input_proxy_port : int
         # PubSub
         input_topic : str
         input_message : str
         input_count : int
         # Websockets
-        input_signingRegion : str
+        input_signing_region : str
         # Cognito
-        input_cognitoIdentity : str
+        input_cognito_identity : str
         # Custom auth
-        input_customAuthUsername : str
-        input_customAuthorizerName : str
-        input_customAuthorizerSignature : str
-        input_customAuthPassword : str
+        input_custom_auth_username : str
+        input_custom_authorizer_name : str
+        input_custom_authorizer_signature : str
+        input_custom_auth_password : str
         # Fleet provisioning
-        input_templateName : str
-        input_templateParameters : str
-        input_csrPath : str
+        input_template_name : str
+        input_template_parameters : str
+        input_csr_path : str
         # Services (Shadow, Jobs, Greengrass, etc)
-        input_thingName : str
+        input_thing_name : str
         input_mode : str
         # Shared Subscription
-        input_groupIdentifier : str
+        input_group_identifier : str
         # PKCS#11
-        input_pkcs11LibPath : str
-        input_pkcs11UserPin : str
-        input_pkcs11TokenLabel : str
-        input_pkcs11SlotId : int
-        input_pkcs11KeyLabel : str
+        input_pkcs11_lib_path : str
+        input_pkcs11_user_pin : str
+        input_pkcs11_token_label : str
+        input_pkcs11_slot_id : int
+        input_pkcs11_key_label : str
         # X509
-        input_x509Endpoint : str
-        input_x509Role : str
-        input_x509ThingName : str
-        input_x509Cert : str
-        input_x509Key : str
-        input_x509Ca : str
-        # PKCS12
-        input_pkcs12File : str
-        input_pkcs12Password : str
+        input_x509_endpoint : str
+        input_x509_role : str
+        input_x509_thing_name : str
+        input_x509_cert : str
+        input_x509_key : str
+        input_x509_ca : str
         # Basic discovery
-        input_maxPubOps : int
-        input_printDiscoveryRespOnly : bool
+        input_max_pub_ops : int
+        input_print_discovery_resp_only : bool
         # Jobs
-        input_jobTime : int
+        input_job_time : int
         # Shadow
-        input_shadowProperty : str
+        input_shadow_property : str
 
         def __init__(self) -> None:
             pass
+
+        def parse_input_topic(self, cmdUtils):
+            self.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+            if (cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci) != None):
+                self.input_topic += "/" + str(uuid4())
 
     def parse_sample_input_basic_connect():
         # Parse arguments
@@ -518,8 +305,8 @@ class CommandLineUtils:
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
@@ -549,18 +336,18 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+        cmdData.parse_input_topic(cmdUtils)
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
-        cmdData.input_thingName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
+        cmdData.input_thing_name = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
         cmdData.input_mode = cmdUtils.get_command(CommandLineUtils.m_cmd_mode, "both")
-        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
-        cmdData.input_maxPubOps = int(cmdUtils.get_command(CommandLineUtils.m_cmd_max_pub_ops, 10))
-        cmdData.input_printDiscoveryRespOnly = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_print_discovery_resp_only, False))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_max_pub_ops = int(cmdUtils.get_command(CommandLineUtils.m_cmd_max_pub_ops, 10))
+        cmdData.input_print_discovery_resp_only = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_print_discovery_resp_only, False))
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
@@ -582,11 +369,11 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
-        cmdData.input_cognitoIdentity = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cognito_identity)
+        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_cognito_identity = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cognito_identity)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
@@ -606,11 +393,11 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
-        cmdData.input_customAuthorizerName = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_name)
-        cmdData.input_customAuthorizerSignature = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_signature)
-        cmdData.input_customAuthPassword = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_password)
-        cmdData.input_customAuthUsername = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
+        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_custom_authorizer_name = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_name)
+        cmdData.input_custom_authorizer_signature = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_signature)
+        cmdData.input_custom_auth_password = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_password)
+        cmdData.input_custom_auth_username = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
@@ -636,11 +423,11 @@ class CommandLineUtils:
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_csrPath = cmdUtils.get_command(CommandLineUtils.m_cmd_csr, None)
-        cmdData.input_templateName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_template_name)
-        cmdData.input_templateParameters = cmdUtils.get_command_required(CommandLineUtils.m_cmd_template_parameters)
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_csr_path = cmdUtils.get_command(CommandLineUtils.m_cmd_csr, None)
+        cmdData.input_template_name = cmdUtils.get_command_required(CommandLineUtils.m_cmd_template_name)
+        cmdData.input_template_parameters = cmdUtils.get_command_required(CommandLineUtils.m_cmd_template_parameters)
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
@@ -663,11 +450,10 @@ class CommandLineUtils:
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_csrPath = cmdUtils.get_command(CommandLineUtils.m_cmd_csr, None)
-        cmdData.input_thingName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
-        cmdData.input_jobTime = int(cmdUtils.get_command(CommandLineUtils.m_cmd_job_time, 5))
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_thing_name = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
+        cmdData.input_job_time = int(cmdUtils.get_command(CommandLineUtils.m_cmd_job_time, 5))
         return cmdData
 
     def parse_sample_input_mqtt5_custom_authorizer_connect():
@@ -684,13 +470,16 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
-        cmdData.input_customAuthorizerName = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_name)
-        cmdData.input_customAuthorizerSignature = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_signature)
-        cmdData.input_customAuthPassword = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_password)
-        cmdData.input_customAuthUsername = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
+        cmdData.input_signing_region = cmdUtils.get_command(CommandLineUtils.m_cmd_signing_region, None)
+        cmdData.input_cert = cmdUtils.get_command(CommandLineUtils.m_cmd_cert_file, None)
+        cmdData.input_key = cmdUtils.get_command(CommandLineUtils.m_cmd_key_file, None)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_custom_authorizer_name = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_name)
+        cmdData.input_custom_authorizer_signature = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_signature)
+        cmdData.input_custom_auth_password = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_password)
+        cmdData.input_custom_auth_username = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_useWebsockets = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_use_websockets, False))
+        cmdData.input_use_websockets = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_use_websockets, False))
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
@@ -719,17 +508,17 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, None))
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_pkcs11LibPath = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
-        cmdData.input_pkcs11UserPin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
-        cmdData.input_pkcs11TokenLabel = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_token)
-        cmdData.input_pkcs11SlotId = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
-        cmdData.input_pkcs11KeyLabel = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
+        cmdData.input_pkcs11_lib_path = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
+        cmdData.input_pkcs11_user_pin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
+        cmdData.input_pkcs11_token_label = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_token)
+        cmdData.input_pkcs11_slot_id = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
+        cmdData.input_pkcs11_key_label = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
@@ -765,10 +554,10 @@ class CommandLineUtils:
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
-        cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+        cmdData.parse_input_topic(cmdUtils)
         cmdData.input_count = int(cmdUtils.get_command(CommandLineUtils.m_cmd_count, 10))
         return cmdData
 
@@ -811,11 +600,11 @@ class CommandLineUtils:
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
-        cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
-        cmdData.input_groupIdentifier = cmdUtils.get_command(CommandLineUtils.m_cmd_group_identifier, "python-sample")
+        cmdData.parse_input_topic(cmdUtils)
+        cmdData.input_group_identifier = cmdUtils.get_command(CommandLineUtils.m_cmd_group_identifier, "python-sample")
         return cmdData
 
     def parse_sample_input_pkcs11_connect():
@@ -839,17 +628,17 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, None))
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_pkcs11LibPath = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
-        cmdData.input_pkcs11UserPin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
-        cmdData.input_pkcs11TokenLabel = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_token)
-        cmdData.input_pkcs11SlotId = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
-        cmdData.input_pkcs11KeyLabel = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
+        cmdData.input_pkcs11_lib_path = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
+        cmdData.input_pkcs11_user_pin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
+        cmdData.input_pkcs11_token_label = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_token)
+        cmdData.input_pkcs11_slot_id = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
+        cmdData.input_pkcs11_key_label = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
@@ -872,10 +661,10 @@ class CommandLineUtils:
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
-        cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+        cmdData.parse_input_topic(cmdUtils)
         cmdData.input_count = int(cmdUtils.get_command(CommandLineUtils.m_cmd_count, 10))
         return cmdData
 
@@ -898,10 +687,10 @@ class CommandLineUtils:
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_thingName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
-        cmdData.input_shadowProperty = cmdUtils.get_command_required(CommandLineUtils.m_cmd_shadow_property)
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_thing_name = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
+        cmdData.input_shadow_property = cmdUtils.get_command_required(CommandLineUtils.m_cmd_shadow_property)
         return cmdData
 
     def parse_sample_input_websocket_connect():
@@ -919,10 +708,10 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
@@ -963,16 +752,16 @@ class CommandLineUtils:
 
         cmdData = CommandLineUtils.CmdData()
         cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
-        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_signing_region = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
-        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_x509Endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_endpoint)
-        cmdData.input_x509ThingName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_thing_name)
-        cmdData.input_x509Role = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_role_alias)
-        cmdData.input_x509Cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_cert)
-        cmdData.input_x509Key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_key)
-        cmdData.input_x509Ca = cmdUtils.get_command(CommandLineUtils.m_cmd_x509_ca, None)
+        cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_x509_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_endpoint)
+        cmdData.input_x509_thing_name = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_thing_name)
+        cmdData.input_x509_role = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_role_alias)
+        cmdData.input_x509_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_cert)
+        cmdData.input_x509_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_key)
+        cmdData.input_x509_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_x509_ca, None)
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -227,7 +227,7 @@ class CommandLineUtils:
         input_ca : str
         input_clientId : str
         input_port : int
-        input_isCI : bool
+        input_is_ci : bool
         input_use_websockets : bool
         # Proxy
         input_proxy_host : str
@@ -309,7 +309,7 @@ class CommandLineUtils:
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_basic_discovery():
@@ -350,7 +350,7 @@ class CommandLineUtils:
         cmdData.input_print_discovery_resp_only = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_print_discovery_resp_only, False))
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_cognito_connect():
@@ -376,7 +376,7 @@ class CommandLineUtils:
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_custom_authorizer_connect():
@@ -401,7 +401,7 @@ class CommandLineUtils:
         cmdData.input_custom_auth_password = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_password)
         cmdData.input_custom_auth_username = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
 
@@ -430,7 +430,7 @@ class CommandLineUtils:
         cmdData.input_csr_path = cmdUtils.get_command(CommandLineUtils.m_cmd_csr, None)
         cmdData.input_template_name = cmdUtils.get_command_required(CommandLineUtils.m_cmd_template_name)
         cmdData.input_template_parameters = cmdUtils.get_command_required(CommandLineUtils.m_cmd_template_parameters)
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_jobs():
@@ -456,6 +456,7 @@ class CommandLineUtils:
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_thing_name = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
         cmdData.input_job_time = int(cmdUtils.get_command(CommandLineUtils.m_cmd_job_time, 5))
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_mqtt5_custom_authorizer_connect():
@@ -482,7 +483,7 @@ class CommandLineUtils:
         cmdData.input_custom_auth_username = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_use_websockets = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_use_websockets, False))
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_mqtt5_pkcs11_connect():
@@ -521,7 +522,7 @@ class CommandLineUtils:
         cmdData.input_pkcs11_token_label = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_token)
         cmdData.input_pkcs11_slot_id = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
         cmdData.input_pkcs11_key_label = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_mqtt5_pubsub():
@@ -561,6 +562,7 @@ class CommandLineUtils:
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
         cmdData.parse_input_topic(cmdUtils)
         cmdData.input_count = int(cmdUtils.get_command(CommandLineUtils.m_cmd_count, 10))
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_mqtt5_shared_subscription():
@@ -607,6 +609,7 @@ class CommandLineUtils:
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
         cmdData.parse_input_topic(cmdUtils)
         cmdData.input_group_identifier = cmdUtils.get_command(CommandLineUtils.m_cmd_group_identifier, "python-sample")
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_pkcs11_connect():
@@ -641,7 +644,7 @@ class CommandLineUtils:
         cmdData.input_pkcs11_token_label = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_token)
         cmdData.input_pkcs11_slot_id = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
         cmdData.input_pkcs11_key_label = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_pubsub():
@@ -668,6 +671,7 @@ class CommandLineUtils:
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
         cmdData.parse_input_topic(cmdUtils)
         cmdData.input_count = int(cmdUtils.get_command(CommandLineUtils.m_cmd_count, 10))
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_shadow():
@@ -693,6 +697,7 @@ class CommandLineUtils:
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_thing_name = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
         cmdData.input_shadow_property = cmdUtils.get_command_required(CommandLineUtils.m_cmd_shadow_property)
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_websocket_connect():
@@ -714,7 +719,7 @@ class CommandLineUtils:
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_windows_cert_connect():
@@ -734,7 +739,7 @@ class CommandLineUtils:
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
     def parse_sample_input_x509_connect():
@@ -743,13 +748,12 @@ class CommandLineUtils:
         cmdUtils.add_common_proxy_commands()
         cmdUtils.add_common_logging_commands()
         cmdUtils.add_common_x509_commands()
-        cmdUtils.register_command("signing_region", "<str>",
+        cmdUtils.register_command(CommandLineUtils.m_cmd_signing_region, "<str>",
                                 "The signing region used for the websocket signer",
                                 True, str)
-        cmdUtils.register_command("client_id", "<str>",
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
                                 "Client ID to use for MQTT connection (optional, default='test-*').",
                                 default="test-" + str(uuid4()))
-        cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -764,7 +768,7 @@ class CommandLineUtils:
         cmdData.input_x509_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_cert)
         cmdData.input_x509_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_key)
         cmdData.input_x509_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_x509_ca, None)
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -463,6 +463,8 @@ class CommandLineUtils:
         cmdUtils = CommandLineUtils(
             "Custom Authorizer Connect - Make a MQTT5 Client connection using a custom authorizer.")
         cmdUtils.add_common_mqtt_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_key_file, "<path>", "Path to your key in PEM format.", False, str)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_cert_file, "<path>", "Path to your client certificate in PEM format.", False, str)
         cmdUtils.add_common_logging_commands()
         cmdUtils.add_common_custom_authorizer_commands()
         cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -554,6 +554,34 @@ class CommandLineUtils:
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
+    def parse_sample_input_cognito_connect():
+        # Parse arguments
+        cmdUtils = CommandLineUtils("Cognito Connect - Make a Cognito MQTT connection.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_signing_region, "<str>",
+                                "The signing region used for the websocket signer",
+                                True, str)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
+                                "Client ID to use for MQTT connection (optional, default='test-*').",
+                                default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_cognito_identity, "<str>",
+                                "The Cognito identity ID to use to connect via Cognito",
+                                True, str)
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_cognitoIdentity = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cognito_identity)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
 
     # Constants for commonly used/needed commands
     m_cmd_endpoint = "endpoint"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -96,6 +96,12 @@ class CommandLineUtils:
             "Path to AmazonRootCA1.pem (optional, system trust store used by default)",
             False,
             str)
+        self.register_command(
+            CommandLineUtils.m_cmd_is_ci,
+            "<str>",
+            "If present the sample will run in CI mode (optional, default='None')",
+            False,
+            str)
 
     def add_common_proxy_commands(self):
         self.register_command(
@@ -683,6 +689,47 @@ class CommandLineUtils:
         cmdData.input_customAuthUsername = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_useWebsockets = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_use_websockets, False))
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
+    def parse_sample_input_mqtt5_pkcs11_connect():
+        cmdUtils = CommandLineUtils("MQTT5 PKCS11 Connect - Make a MQTT5 Client connection using PKCS11.")
+        cmdUtils.add_common_mqtt5_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_cert_file, "<path>", "Path to your client certificate in PEM format.", True, str)
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_port,
+            "<int>",
+            "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
+            type=int)
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_client_id,
+            "<str>",
+            "Client ID to use for MQTT5 connection (optional, default=None).",
+            default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_lib, "<path>", "Path to PKCS#11 Library", required=True)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_pin, "<str>", "User PIN for logging into PKCS#11 token.", required=True)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_token, "<str>", "Label of the PKCS#11 token to use (optional).")
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_slot, "<int>", "Slot ID containing the PKCS#11 token to use (optional).", False, int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_key, "<str>", "Label of private key on the PKCS#11 token (optional).")
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_cognitoIdentity = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cognito_identity)
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, None))
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_pkcs11LibPath = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_lib)
+        cmdData.input_pkcs11UserPin = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_pin)
+        cmdData.input_pkcs11TokenLabel = cmdUtils.get_command_required(CommandLineUtils.m_cmd_pkcs11_token)
+        cmdData.input_pkcs11SlotId = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_slot, None)
+        cmdData.input_pkcs11KeyLabel = cmdUtils.get_command(CommandLineUtils.m_cmd_pkcs11_key, None)
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -121,7 +121,7 @@ class CommandLineUtils:
             CommandLineUtils.m_cmd_message,
             "<str>",
             "The message to send in the payload (optional, default='Hello World!').",
-            default="Hello World!")
+            default="Hello World! ")
 
     def add_common_logging_commands(self):
         self.register_command(
@@ -476,6 +476,9 @@ class CommandLineUtils:
         # PKCS12
         input_pkcs12File : str
         input_pkcs12Password : str
+        # Basic discovery
+        input_maxPubOps : int
+        input_printDiscoveryRespOnly : bool
 
         def __init__(self) -> None:
             pass
@@ -504,9 +507,51 @@ class CommandLineUtils:
         cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
         cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
-        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
+    def parse_sample_input_basic_discovery():
+        allowed_actions = ['both', 'publish', 'subscribe']
+        # Parse arguments
+        cmdUtils = CommandLineUtils("Basic Discovery - Greengrass discovery example.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_topic_message_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_key_cert_commands()
+        cmdUtils.remove_command(CommandLineUtils.m_cmd_endpoint)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_thing_name, "<str>", "The name assigned to your IoT Thing", required=True)
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_mode, "<mode>",
+            f"The operation mode (optional, default='both').\nModes:{allowed_actions}", default='both')
+        cmdUtils.register_command(CommandLineUtils.m_cmd_signing_region, "<str>", "The region to connect through.", required=True)
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_max_pub_ops, "<int>",
+            "The maximum number of publish operations (optional, default='10').",
+            default=10, type=int)
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_print_discovery_resp_only, "", "(optional, default='False').",
+            default=False, type=bool, action="store_true")
+        cmdUtils.add_common_proxy_commands()
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+        cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_thingName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
+        cmdData.input_mode = cmdUtils.get_command(CommandLineUtils.m_cmd_mode, "both")
+        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_maxPubOps = int(cmdUtils.get_command(CommandLineUtils.m_cmd_max_pub_ops, 10))
+        cmdData.input_printDiscoveryRespOnly = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_print_discovery_resp_only, False))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
 
@@ -541,3 +586,7 @@ class CommandLineUtils:
     m_cmd_port = "port"
     m_cmd_client_id = "client_id"
     m_cmd_is_ci = "is_ci"
+    m_cmd_thing_name = "thing_name"
+    m_cmd_mode = "mode"
+    m_cmd_max_pub_ops = "max_pub_ops"
+    m_cmd_print_discovery_resp_only = "print_discover_resp_only"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -602,6 +602,36 @@ class CommandLineUtils:
         return cmdData
 
 
+    def parse_sample_input_fleet_provisioning():
+        cmdUtils = CommandLineUtils("Fleet Provisioning - Provision device using either the keys or CSR.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_key_cert_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_csr, "<path>", "Path to CSR in Pem format (optional).")
+        cmdUtils.register_command(CommandLineUtils.m_cmd_template_name, "<str>", "The name of your provisioning template.")
+        cmdUtils.register_command(CommandLineUtils.m_cmd_template_parameters, "<json>", "Template parameters json.")
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_csrPath = cmdUtils.get_command(CommandLineUtils.m_cmd_csr, None)
+        cmdData.input_templateName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_template_name)
+        cmdData.input_templateParameters = cmdUtils.get_command_required(CommandLineUtils.m_cmd_template_parameters)
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
+
     # Constants for commonly used/needed commands
     m_cmd_endpoint = "endpoint"
     m_cmd_ca_file = "ca_file"
@@ -637,3 +667,6 @@ class CommandLineUtils:
     m_cmd_mode = "mode"
     m_cmd_max_pub_ops = "max_pub_ops"
     m_cmd_print_discovery_resp_only = "print_discover_resp_only"
+    m_cmd_csr = "csr"
+    m_cmd_template_name = "template_name"
+    m_cmd_template_parameters = "template_parameters"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -435,6 +435,7 @@ class CommandLineUtils:
         input_clientId : str
         input_port : int
         input_isCI : bool
+        input_useWebsockets : bool
         # Proxy
         input_proxyHost : str
         input_proxyPort : int
@@ -660,6 +661,31 @@ class CommandLineUtils:
         cmdData.input_jobTime = int(cmdUtils.get_command(CommandLineUtils.m_cmd_job_time, 5))
         return cmdData
 
+    def parse_sample_input_mqtt5_custom_authorizer_connect():
+        cmdUtils = CommandLineUtils(
+            "Custom Authorizer Connect - Make a MQTT5 Client connection using a custom authorizer.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_custom_authorizer_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
+                                "Client ID to use for MQTT connection (optional, default='test-*').",
+                                default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_use_websockets, "<str>", "If set, websockets will be used (optional, do not set to use direct MQTT)")
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_customAuthorizerName = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_name)
+        cmdData.input_customAuthorizerSignature = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_signature)
+        cmdData.input_customAuthPassword = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_password)
+        cmdData.input_customAuthUsername = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_useWebsockets = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_use_websockets, False))
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
 
     # Constants for commonly used/needed commands
     m_cmd_endpoint = "endpoint"
@@ -700,3 +726,4 @@ class CommandLineUtils:
     m_cmd_template_name = "template_name"
     m_cmd_template_parameters = "template_parameters"
     m_cmd_job_time = "job_time"
+    m_cmd_use_websockets = "use_websockets"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -514,7 +514,7 @@ class CommandLineUtils:
 
     def parse_sample_input_basic_discovery():
         allowed_actions = ['both', 'publish', 'subscribe']
-        # Parse arguments
+
         cmdUtils = CommandLineUtils("Basic Discovery - Greengrass discovery example.")
         cmdUtils.add_common_mqtt_commands()
         cmdUtils.add_common_topic_message_commands()
@@ -534,7 +534,6 @@ class CommandLineUtils:
             CommandLineUtils.m_cmd_print_discovery_resp_only, "", "(optional, default='False').",
             default=False, type=bool, action="store_true")
         cmdUtils.add_common_proxy_commands()
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -555,7 +554,6 @@ class CommandLineUtils:
         return cmdData
 
     def parse_sample_input_cognito_connect():
-        # Parse arguments
         cmdUtils = CommandLineUtils("Cognito Connect - Make a Cognito MQTT connection.")
         cmdUtils.add_common_mqtt_commands()
         cmdUtils.add_common_proxy_commands()
@@ -569,7 +567,6 @@ class CommandLineUtils:
         cmdUtils.register_command(CommandLineUtils.m_cmd_cognito_identity, "<str>",
                                 "The Cognito identity ID to use to connect via Cognito",
                                 True, str)
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -579,6 +576,28 @@ class CommandLineUtils:
         cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
+    def parse_sample_input_custom_authorizer_connect():
+        cmdUtils = CommandLineUtils(
+            "Custom Authorizer Connect - Make a MQTT connection using a custom authorizer.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_custom_authorizer_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
+                                "Client ID to use for MQTT connection (optional, default='test-*').",
+                                default="test-" + str(uuid4()))
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_customAuthorizerName = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_name)
+        cmdData.input_customAuthorizerSignature = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_authorizer_signature)
+        cmdData.input_customAuthPassword = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_password)
+        cmdData.input_customAuthUsername = cmdUtils.get_command(CommandLineUtils.m_cmd_custom_auth_username)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -488,6 +488,8 @@ class CommandLineUtils:
         input_printDiscoveryRespOnly : bool
         # Jobs
         input_jobTime : int
+        # Shadow
+        input_shadowProperty : str
 
         def __init__(self) -> None:
             pass
@@ -594,6 +596,9 @@ class CommandLineUtils:
         cmdUtils.add_common_mqtt_commands()
         cmdUtils.add_common_logging_commands()
         cmdUtils.add_common_custom_authorizer_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_signing_region, "<str>",
+                                "The signing region used for the websocket signer",
+                                True, str)
         cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
                                 "Client ID to use for MQTT connection (optional, default='test-*').",
                                 default="test-" + str(uuid4()))
@@ -622,7 +627,6 @@ class CommandLineUtils:
         cmdUtils.register_command(CommandLineUtils.m_cmd_csr, "<path>", "Path to CSR in Pem format (optional).")
         cmdUtils.register_command(CommandLineUtils.m_cmd_template_name, "<str>", "The name of your provisioning template.")
         cmdUtils.register_command(CommandLineUtils.m_cmd_template_parameters, "<json>", "Template parameters json.")
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -650,7 +654,6 @@ class CommandLineUtils:
         cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_thing_name, "<str>", "The name assigned to your IoT Thing", required=True)
         cmdUtils.register_command(CommandLineUtils.m_cmd_job_time, "<int>", "Emulate working on a job by sleeping this many seconds (optional, default='5')", default=5, type=int)
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -677,7 +680,6 @@ class CommandLineUtils:
                                 "Client ID to use for MQTT connection (optional, default='test-*').",
                                 default="test-" + str(uuid4()))
         cmdUtils.register_command(CommandLineUtils.m_cmd_use_websockets, "<str>", "If set, websockets will be used (optional, do not set to use direct MQTT)")
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -713,7 +715,6 @@ class CommandLineUtils:
         cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_token, "<str>", "Label of the PKCS#11 token to use (optional).")
         cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_slot, "<int>", "Slot ID containing the PKCS#11 token to use (optional).", False, int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_key, "<str>", "Label of private key on the PKCS#11 token (optional).")
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -755,7 +756,6 @@ class CommandLineUtils:
             "The number of messages to send (optional, default='10').",
             default=10,
             type=int)
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -802,7 +802,6 @@ class CommandLineUtils:
             "The group identifier to use in the shared subscription (optional, default='python-sample')",
             default="python-sample",
             type=str)
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -836,7 +835,6 @@ class CommandLineUtils:
         cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_token, "<str>", "Label of the PKCS#11 token to use (optional).")
         cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_slot, "<int>", "Slot ID containing the PKCS#11 token to use (optional).", False, int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_pkcs11_key, "<str>", "Label of private key on the PKCS#11 token (optional).")
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -865,7 +863,6 @@ class CommandLineUtils:
         cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
         cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
         cmdUtils.register_command(CommandLineUtils.m_cmd_count, "<int>", "The number of messages to send (optional, default='10').", default=10, type=int)
-        # Needs to be called so the command utils parse the commands
         cmdUtils.get_args()
 
         cmdData = CommandLineUtils.CmdData()
@@ -880,6 +877,103 @@ class CommandLineUtils:
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
         cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
         cmdData.input_count = int(cmdUtils.get_command(CommandLineUtils.m_cmd_count, 10))
+        return cmdData
+
+    def parse_sample_input_shadow():
+        cmdUtils = CommandLineUtils("Shadow - Keep a property in sync between device and server.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_key_cert_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>", "Client ID to use for MQTT connection (optional, default='test-*').", default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_thing_name, "<str>", "The name assigned to your IoT Thing", required=True)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_shadow_property, "<str>", "The name of the shadow property you want to change (optional, default='color'", default="color")
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_thingName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_thing_name)
+        cmdData.input_shadowProperty = cmdUtils.get_command_required(CommandLineUtils.m_cmd_shadow_property)
+        return cmdData
+
+    def parse_sample_input_websocket_connect():
+        cmdUtils = CommandLineUtils("Websocket Connect - Make a websocket MQTT connection.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_signing_region, "<str>",
+                                "The signing region used for the websocket signer",
+                                True, str)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
+                                "Client ID to use for MQTT connection (optional, default='test-*').",
+                                default="test-" + str(uuid4()))
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
+    def parse_sample_input_windows_cert_connect():
+        cmdUtils = CommandLineUtils("Windows Cert Connect - Make a MQTT connection using Windows Store Certificates.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
+                                "Client ID to use for MQTT connection (optional, default='test-*').",
+                                default="test-" + str(uuid4()))
+        cmdUtils.register_command(CommandLineUtils.m_cmd_cert_file, "<path>", "Path to certificate in Windows cert store. "
+                                    "e.g. \"CurrentUser\\MY\\6ac133ac58f0a88b83e9c794eba156a98da39b4c\"", True, str)
+        cmdUtils.register_command(CommandLineUtils.m_cmd_port, "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
+        return cmdData
+
+    def parse_sample_input_x509_connect():
+        cmdUtils = CommandLineUtils("X509 Connect - Make a MQTT connection using X509.")
+        cmdUtils.add_common_mqtt_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_x509_commands()
+        cmdUtils.register_command("signing_region", "<str>",
+                                "The signing region used for the websocket signer",
+                                True, str)
+        cmdUtils.register_command("client_id", "<str>",
+                                "Client ID to use for MQTT connection (optional, default='test-*').",
+                                default="test-" + str(uuid4()))
+        cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_signingRegion = cmdUtils.get_command_required(CommandLineUtils.m_cmd_signing_region)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_x509Endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_endpoint)
+        cmdData.input_x509ThingName = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_thing_name)
+        cmdData.input_x509Role = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_role_alias)
+        cmdData.input_x509Cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_cert)
+        cmdData.input_x509Key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_x509_key)
+        cmdData.input_x509Ca = cmdUtils.get_command(CommandLineUtils.m_cmd_x509_ca, None)
+        cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
 
@@ -925,3 +1019,4 @@ class CommandLineUtils:
     m_cmd_use_websockets = "use_websockets"
     m_cmd_count = "count"
     m_cmd_group_identifier = "group_identifier"
+    m_cmd_shadow_property = "shadow_property"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -733,6 +733,45 @@ class CommandLineUtils:
         cmdData.input_isCI = cmdUtils.get_command("is_ci", None) != None
         return cmdData
 
+    def parse_sample_input_mqtt5_pubsub():
+        cmdUtils = CommandLineUtils("PubSub - Send and receive messages through an MQTT5 connection.")
+        cmdUtils.add_common_mqtt5_commands()
+        cmdUtils.add_common_topic_message_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_key_cert_commands()
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_port,
+            "<int>",
+            "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
+            type=int)
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_client_id,
+            "<str>",
+            "Client ID to use for MQTT5 connection (optional, default=None).",
+            default="test-" + str(uuid4()))
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_count,
+            "<int>",
+            "The number of messages to send (optional, default='10').",
+            default=10,
+            type=int)
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
+        cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+        return cmdData
+
 
     # Constants for commonly used/needed commands
     m_cmd_endpoint = "endpoint"
@@ -774,3 +813,4 @@ class CommandLineUtils:
     m_cmd_template_parameters = "template_parameters"
     m_cmd_job_time = "job_time"
     m_cmd_use_websockets = "use_websockets"
+    m_cmd_count = "count"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -772,6 +772,53 @@ class CommandLineUtils:
         cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
         return cmdData
 
+    def parse_sample_input_mqtt5_shared_subscription():
+        cmdUtils = CommandLineUtils("SharedSubscription - Send and receive messages through a MQTT5 shared subscription")
+        cmdUtils.add_common_mqtt5_commands()
+        cmdUtils.add_common_topic_message_commands()
+        cmdUtils.add_common_proxy_commands()
+        cmdUtils.add_common_logging_commands()
+        cmdUtils.add_common_key_cert_commands()
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_port,
+            "<int>",
+            "Connection port. AWS IoT supports 433 and 8883 (optional, default=auto).",
+            type=int)
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_client_id,
+            "<str>",
+            "Client ID to use for MQTT5 connection (optional, default=None)."
+            "Note that '1', '2', and '3' will be added for to the given clientIDs since this sample uses 3 clients.",
+            default="test-" + str(uuid4()))
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_count,
+            "<int>",
+            "The number of messages to send (optional, default='10').",
+            default=10,
+            type=int)
+        cmdUtils.register_command(
+            CommandLineUtils.m_cmd_group_identifier,
+            "<str>",
+            "The group identifier to use in the shared subscription (optional, default='python-sample')",
+            default="python-sample",
+            type=str)
+        # Needs to be called so the command utils parse the commands
+        cmdUtils.get_args()
+
+        cmdData = CommandLineUtils.CmdData()
+        cmdData.input_endpoint = cmdUtils.get_command_required(CommandLineUtils.m_cmd_endpoint)
+        cmdData.input_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_port, "8883"))
+        cmdData.input_cert = cmdUtils.get_command_required(CommandLineUtils.m_cmd_cert_file)
+        cmdData.input_key = cmdUtils.get_command_required(CommandLineUtils.m_cmd_key_file)
+        cmdData.input_ca = cmdUtils.get_command(CommandLineUtils.m_cmd_ca_file, None)
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
+        cmdData.input_proxyHost = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
+        cmdData.input_proxyPort = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
+        cmdData.input_topic = cmdUtils.get_command(CommandLineUtils.m_cmd_topic, "test/topic")
+        cmdData.input_groupIdentifier = cmdUtils.get_command(CommandLineUtils.m_cmd_group_identifier, "python-sample")
+        return cmdData
+
 
     # Constants for commonly used/needed commands
     m_cmd_endpoint = "endpoint"
@@ -814,3 +861,4 @@ class CommandLineUtils:
     m_cmd_job_time = "job_time"
     m_cmd_use_websockets = "use_websockets"
     m_cmd_count = "count"
+    m_cmd_group_identifier = "group_identifier"

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -608,6 +608,7 @@ class CommandLineUtils:
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
         cmdData.input_message = cmdUtils.get_command(CommandLineUtils.m_cmd_message, "Hello World! ")
         cmdData.parse_input_topic(cmdUtils)
+        cmdData.input_count = cmdUtils.get_command(CommandLineUtils.m_cmd_count, 10)
         cmdData.input_group_identifier = cmdUtils.get_command(CommandLineUtils.m_cmd_group_identifier, "python-sample")
         cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -781,7 +781,7 @@ class CommandLineUtils:
     m_cmd_key_file = "key"
     m_cmd_proxy_host = "proxy_host"
     m_cmd_proxy_port = "proxy_port"
-    m_cmd_signing_region = "signing_region"
+    m_cmd_signing_region = "region"
     m_cmd_pkcs11_lib = "pkcs11_lib"
     m_cmd_pkcs11_cert = "cert"
     m_cmd_pkcs11_pin = "pin"

--- a/samples/websocket_connect.py
+++ b/samples/websocket_connect.py
@@ -25,16 +25,16 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 if __name__ == '__main__':
     # Create the proxy options if the data is present in cmdData
     proxy_options = None
-    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+    if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=cmdData.input_proxyHost,
-            port=cmdData.input_proxyPort)
+            host_name=cmdData.input_proxy_host,
+            port=cmdData.input_proxy_port)
 
     # Create a default credentials provider and a MQTT connection from the command line data
     credentials_provider = auth.AwsCredentialsProvider.new_default_chain()
     mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
         endpoint=cmdData.input_endpoint,
-        region=cmdData.input_signingRegion,
+        region=cmdData.input_signing_region,
         credentials_provider=credentials_provider,
         http_proxy_options=proxy_options,
         ca_filepath=cmdData.input_ca,
@@ -44,10 +44,10 @@ if __name__ == '__main__':
         clean_session=False,
         keep_alive_secs=30)
 
-    if cmdData.input_isCI == False:
+    if not cmdData.input_isCI:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
-        print ("Connecting to endpoint with client ID...")
+        print("Connecting to endpoint with client ID...")
 
     connect_future = mqtt_connection.connect()
 

--- a/samples/websocket_connect.py
+++ b/samples/websocket_connect.py
@@ -1,27 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-from uuid import uuid4
+from awscrt import http, auth
+from awsiot import mqtt_connection_builder
+from utils.command_line_utils import CommandLineUtils
 
 # This sample shows how to create a MQTT connection using websockets.
 # This sample is intended to be used as a reference for making MQTT connections.
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("Websocket Connect - Make a websocket MQTT connection.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_proxy_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("signing_region", "<str>",
-                          "The signing region used for the websocket signer",
-                          True, str)
-cmdUtils.register_command("client_id", "<str>",
-                          "Client ID to use for MQTT connection (optional, default='test-*').",
-                          default="test-" + str(uuid4()))
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
-is_ci = cmdUtils.get_command("is_ci", None) != None
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_websocket_connect()
 
 # Callback when connection is accidentally lost.
 def on_connection_interrupted(connection, error, **kwargs):
@@ -33,14 +23,29 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 
 
 if __name__ == '__main__':
-    # Create a connection using websockets.
-    # Note: The data for the connection is gotten from cmdUtils.
-    # (see build_websocket_mqtt_connection for implementation)
-    mqtt_connection = cmdUtils.build_websocket_mqtt_connection(on_connection_interrupted, on_connection_resumed)
+    # Create the proxy options if the data is present in cmdData
+    proxy_options = None
+    if cmdData.input_proxyHost is not None and cmdData.input_proxyPort != 0:
+        proxy_options = http.HttpProxyOptions(
+            host_name=cmdData.input_proxyHost,
+            port=cmdData.input_proxyPort)
 
-    if is_ci == False:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+    # Create a default credentials provider and a MQTT connection from the command line data
+    credentials_provider = auth.AwsCredentialsProvider.new_default_chain()
+    mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
+        endpoint=cmdData.input_endpoint,
+        region=cmdData.input_signingRegion,
+        credentials_provider=credentials_provider,
+        http_proxy_options=proxy_options,
+        ca_filepath=cmdData.input_ca,
+        on_connection_interrupted=on_connection_interrupted,
+        on_connection_resumed=on_connection_resumed,
+        client_id=cmdData.input_clientId,
+        clean_session=False,
+        keep_alive_secs=30)
+
+    if cmdData.input_isCI == False:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print ("Connecting to endpoint with client ID...")
 

--- a/samples/websocket_connect.py
+++ b/samples/websocket_connect.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
         clean_session=False,
         keep_alive_secs=30)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID...")

--- a/samples/websocket_connect.py
+++ b/samples/websocket_connect.py
@@ -37,7 +37,6 @@ if __name__ == '__main__':
         region=cmdData.input_signing_region,
         credentials_provider=credentials_provider,
         http_proxy_options=proxy_options,
-        ca_filepath=cmdData.input_ca,
         on_connection_interrupted=on_connection_interrupted,
         on_connection_resumed=on_connection_resumed,
         client_id=cmdData.input_clientId,

--- a/samples/windows_cert_connect.py
+++ b/samples/windows_cert_connect.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 from awsiot import mqtt_connection_builder
-from uuid import uuid4
+from utils.command_line_utils import CommandLineUtils
 
 # This sample is similar to `samples/basic_connect.py` but the certificate
 # for mutual TLS is stored in a Windows certificate store.
@@ -12,22 +12,10 @@ from uuid import uuid4
 #
 # WARNING: Windows only.
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("Windows Cert Connect - Make a MQTT connection using Windows Store Certificates.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.register_command("client_id", "<str>",
-                          "Client ID to use for MQTT connection (optional, default='test-*').",
-                          default="test-" + str(uuid4()))
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-cmdUtils.register_command("cert", "<path>", "Path to certificate in Windows cert store. "
-                            "e.g. \"CurrentUser\\MY\\6ac133ac58f0a88b83e9c794eba156a98da39b4c\"", True, str)
-cmdUtils.register_command("port", "<int>", "Connection port. AWS IoT supports 443 and 8883 (optional, default=auto).", type=int)
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
-
-is_ci = cmdUtils.get_command("is_ci", None) != None
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_windows_cert_connect()
 
 def on_connection_interrupted(connection, error, **kwargs):
     # Callback when connection is accidentally lost.
@@ -42,19 +30,18 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 if __name__ == '__main__':
     # Create MQTT connection
     mqtt_connection = mqtt_connection_builder.mtls_with_windows_cert_store_path(
-        cert_store_path=cmdUtils.get_command_required("cert"),
-        endpoint=cmdUtils.get_command_required(cmdUtils.m_cmd_endpoint),
-        port=cmdUtils.get_command("port"),
-        ca_filepath=cmdUtils.get_command(cmdUtils.m_cmd_ca_file),
+        cert_store_path=cmdData.input_cert,
+        endpoint=cmdData.input_endpoint,
+        port=cmdData.input_port,
+        ca_filepath=cmdData.input_ca,
         on_connection_interrupted=on_connection_interrupted,
         on_connection_resumed=on_connection_resumed,
-        client_id=cmdUtils.get_command("client_id"),
+        client_id=cmdData.input_clientId,
         clean_session=False,
         keep_alive_secs=30)
 
-    if is_ci == False:
-        print("Connecting to {} with client ID '{}'...".format(
-            cmdUtils.get_command(cmdUtils.m_cmd_endpoint), cmdUtils.get_command("client_id")))
+    if cmdData.input_isCI == False:
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/windows_cert_connect.py
+++ b/samples/windows_cert_connect.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
         clean_session=False,
         keep_alive_secs=30)
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/windows_cert_connect.py
+++ b/samples/windows_cert_connect.py
@@ -17,6 +17,7 @@ from utils.command_line_utils import CommandLineUtils
 # See the Utils/CommandLineUtils for more information.
 cmdData = CommandLineUtils.parse_sample_input_windows_cert_connect()
 
+
 def on_connection_interrupted(connection, error, **kwargs):
     # Callback when connection is accidentally lost.
     print("Connection interrupted. error: {}".format(error))
@@ -40,7 +41,7 @@ if __name__ == '__main__':
         clean_session=False,
         keep_alive_secs=30)
 
-    if cmdData.input_isCI == False:
+    if not cmdData.input_isCI:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/x509_connect.py
+++ b/samples/x509_connect.py
@@ -55,7 +55,6 @@ if __name__ == '__main__':
         region=cmdData.input_signing_region,
         credentials_provider=x509_provider,
         http_proxy_options=proxy_options,
-        ca_filepath=cmdData.input_ca,
         on_connection_interrupted=on_connection_interrupted,
         on_connection_resumed=on_connection_resumed,
         client_id=cmdData.input_clientId,

--- a/samples/x509_connect.py
+++ b/samples/x509_connect.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
     # Use the MQTT connection to connect and disconnect
     ############################################################
 
-    if not cmdData.input_isCI:
+    if not cmdData.input_is_ci:
         print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")

--- a/samples/x509_connect.py
+++ b/samples/x509_connect.py
@@ -31,28 +31,28 @@ if __name__ == '__main__':
     # Set up the config needed to make a MQTT connection
 
     proxy_options = None
-    if cmdData.input_proxyHost != None and cmdData.input_proxyPort != 0:
+    if cmdData.input_proxy_host is not None and cmdData.input_proxy_port != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=cmdData.input_proxyHost,
-            port=cmdData.input_proxyPort)
+            host_name=cmdData.input_proxy_host,
+            port=cmdData.input_proxy_port)
 
-    x509_tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(cmdData.input_x509Cert, cmdData.input_x509Key)
-    x509_tls_options.ca_dirpath = cmdData.input_x509Ca
+    x509_tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(
+        cmdData.input_x509_cert, cmdData.input_x509_key)
+    x509_tls_options.ca_dirpath = cmdData.input_x509_ca
     x509_tls_context = io.ClientTlsContext(x509_tls_options)
 
     x509_provider = auth.AwsCredentialsProvider.new_x509(
-        endpoint=cmdData.input_x509Endpoint,
-        thing_name=cmdData.input_x509ThingName,
-        role_alias=cmdData.input_x509Role,
+        endpoint=cmdData.input_x509_endpoint,
+        thing_name=cmdData.input_x509_thing_name,
+        role_alias=cmdData.input_x509_role,
         tls_ctx=x509_tls_context,
         http_proxy_options=proxy_options
     )
 
     # Create the MQTT connection from the configuration
-
     mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
-        endpoint=cmdData.input_x509Endpoint,
-        region=cmdData.input_signingRegion,
+        endpoint=cmdData.input_x509_endpoint,
+        region=cmdData.input_signing_region,
         credentials_provider=x509_provider,
         http_proxy_options=proxy_options,
         ca_filepath=cmdData.input_ca,
@@ -67,7 +67,7 @@ if __name__ == '__main__':
     ############################################################
 
     if not cmdData.input_isCI:
-        print (f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
+        print(f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 

--- a/samples/x509_connect.py
+++ b/samples/x509_connect.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 
     # Create the MQTT connection from the configuration
     mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
-        endpoint=cmdData.input_x509_endpoint,
+        endpoint=cmdData.input_endpoint,
         region=cmdData.input_signing_region,
         credentials_provider=x509_provider,
         http_proxy_options=proxy_options,

--- a/samples/x509_connect.py
+++ b/samples/x509_connect.py
@@ -2,29 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0.
 
 from awscrt import io, http, auth
-from uuid import uuid4
 from awsiot import mqtt_connection_builder
+from utils.command_line_utils import CommandLineUtils
 
 # This sample shows how to create a MQTT connection using X509 files to connect.
 # This sample is intended to be used as a reference for making MQTT connections via X509.
 
-# Parse arguments
-import utils.command_line_utils as command_line_utils
-cmdUtils = command_line_utils.CommandLineUtils("X509 Connect - Make a MQTT connection using X509.")
-cmdUtils.add_common_mqtt_commands()
-cmdUtils.add_common_proxy_commands()
-cmdUtils.add_common_logging_commands()
-cmdUtils.add_common_x509_commands()
-cmdUtils.register_command("signing_region", "<str>",
-                          "The signing region used for the websocket signer",
-                          True, str)
-cmdUtils.register_command("client_id", "<str>",
-                          "Client ID to use for MQTT connection (optional, default='test-*').",
-                          default="test-" + str(uuid4()))
-cmdUtils.register_command("is_ci", "<str>", "If present the sample will run in CI mode (optional, default='None')")
-# Needs to be called so the command utils parse the commands
-cmdUtils.get_args()
-is_ci = cmdUtils.get_command("is_ci", None) is not None
+# cmdData is the arguments/input from the command line placed into a single struct for
+# use in this sample. This handles all of the command line parsing, validating, etc.
+# See the Utils/CommandLineUtils for more information.
+cmdData = CommandLineUtils.parse_sample_input_x509_connect()
 
 # Callback when connection is accidentally lost.
 def on_connection_interrupted(connection, error, **kwargs):
@@ -38,43 +25,25 @@ def on_connection_resumed(connection, return_code, session_present, **kwargs):
 if __name__ == '__main__':
 
     ############################################################
-    # Pull data from the command line
-    ############################################################
-    input_endpoint = cmdUtils.get_command_required("endpoint")
-    input_signing_region = cmdUtils.get_command_required("signing_region")
-    input_ca_file = cmdUtils.get_command("ca_file")
-    input_client_id = cmdUtils.get_command_required("client_id")
-
-    input_proxy_host = cmdUtils.get_command("proxy_host")
-    input_proxy_port = cmdUtils.get_command("proxy_port")
-
-    input_x509_endpoint = cmdUtils.get_command_required("x509_endpoint")
-    input_x509_thing_name = cmdUtils.get_command_required("x509_thing_name")
-    input_x509_role_alias = cmdUtils.get_command_required("x509_role_alias")
-    input_x509_cert = cmdUtils.get_command_required("x509_cert")
-    input_x509_key = cmdUtils.get_command_required("x509_key")
-    input_x509_ca_file = cmdUtils.get_command("x509_ca_file")
-
-    ############################################################
     # Set up and create the MQTT connection
     ############################################################
 
     # Set up the config needed to make a MQTT connection
 
     proxy_options = None
-    if input_proxy_host is not None and input_proxy_port is not None:
+    if cmdData.input_proxyHost != None and cmdData.input_proxyPort != 0:
         proxy_options = http.HttpProxyOptions(
-            host_name=input_proxy_host,
-            port=input_proxy_port)
+            host_name=cmdData.input_proxyHost,
+            port=cmdData.input_proxyPort)
 
-    x509_tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(input_x509_cert, input_x509_key)
-    x509_tls_options.ca_dirpath = input_x509_ca_file
+    x509_tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(cmdData.input_x509Cert, cmdData.input_x509Key)
+    x509_tls_options.ca_dirpath = cmdData.input_x509Ca
     x509_tls_context = io.ClientTlsContext(x509_tls_options)
 
     x509_provider = auth.AwsCredentialsProvider.new_x509(
-        endpoint=input_x509_endpoint,
-        thing_name=input_x509_thing_name,
-        role_alias=input_x509_role_alias,
+        endpoint=cmdData.input_x509Endpoint,
+        thing_name=cmdData.input_x509ThingName,
+        role_alias=cmdData.input_x509Role,
         tls_ctx=x509_tls_context,
         http_proxy_options=proxy_options
     )
@@ -82,14 +51,14 @@ if __name__ == '__main__':
     # Create the MQTT connection from the configuration
 
     mqtt_connection = mqtt_connection_builder.websockets_with_default_aws_signing(
-        endpoint=input_endpoint,
-        region=input_signing_region,
+        endpoint=cmdData.input_x509Endpoint,
+        region=cmdData.input_signingRegion,
         credentials_provider=x509_provider,
         http_proxy_options=proxy_options,
-        ca_filepath=input_ca_file,
+        ca_filepath=cmdData.input_ca,
         on_connection_interrupted=on_connection_interrupted,
         on_connection_resumed=on_connection_resumed,
-        client_id=input_client_id,
+        client_id=cmdData.input_clientId,
         clean_session=False,
         keep_alive_secs=30)
 
@@ -97,8 +66,8 @@ if __name__ == '__main__':
     # Use the MQTT connection to connect and disconnect
     ############################################################
 
-    if not is_ci:
-        print (f"Connecting to {input_endpoint} with client ID '{input_client_id}'...")
+    if not cmdData.input_isCI:
+        print (f"Connecting to {cmdData.input_endpoint} with client ID '{cmdData.input_clientId}'...")
     else:
         print("Connecting to endpoint with client ID")
 


### PR DESCRIPTION
*Description of changes:*

Refactors samples not to rely on `cmdUtils` to setup MQTT clients, to connect/disconnect for connect samples, and overall just makes `cmdUtils` go back to command line parsing and nothing more.

Also contains the following minor changes:
* Adjusts all samples to register all command line commands and get the data from said commands in a single function, rather than doing it individually in each sample.
  * This also fixed a few minor inconsistencies that slipped through: like `region` being used in a couple samples instead of `signing_region`.
* Fixes possible Cross-SDK repository communication for PubSub by appending UUIDs to topics

_____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
