### PR TITLE
Greengrass IPC update including MQTT 5 models

### DIFF
--- a/awsiot/greengrasscoreipc/clientv2.py
+++ b/awsiot/greengrasscoreipc/clientv2.py
@@ -511,7 +511,14 @@ class GreengrassCoreIPCClientV2:
     def publish_to_iot_core(self, *,
         topic_name: typing.Optional[str] = None,
         qos: typing.Optional[str] = None,
-        payload: typing.Optional[typing.Union[bytes, str]] = None) -> model.PublishToIoTCoreResponse:
+        payload: typing.Optional[typing.Union[bytes, str]] = None,
+        retain: typing.Optional[bool] = None,
+        user_properties: typing.Optional[typing.List[model.UserProperty]] = None,
+        message_expiry_interval_seconds: typing.Optional[int] = None,
+        correlation_data: typing.Optional[typing.Union[bytes, str]] = None,
+        response_topic: typing.Optional[str] = None,
+        payload_format: typing.Optional[str] = None,
+        content_type: typing.Optional[str] = None) -> model.PublishToIoTCoreResponse:
         """
         Perform the PublishToIoTCore operation synchronously.
 
@@ -519,13 +526,27 @@ class GreengrassCoreIPCClientV2:
             topic_name: 
             qos: QOS enum value
             payload: 
+            retain: 
+            user_properties: 
+            message_expiry_interval_seconds: 
+            correlation_data: 
+            response_topic: 
+            payload_format: PayloadFormat enum value
+            content_type: 
         """
-        return self.publish_to_iot_core_async(topic_name=topic_name, qos=qos, payload=payload).result()
+        return self.publish_to_iot_core_async(topic_name=topic_name, qos=qos, payload=payload, retain=retain, user_properties=user_properties, message_expiry_interval_seconds=message_expiry_interval_seconds, correlation_data=correlation_data, response_topic=response_topic, payload_format=payload_format, content_type=content_type).result()
 
     def publish_to_iot_core_async(self, *,
         topic_name: typing.Optional[str] = None,
         qos: typing.Optional[str] = None,
-        payload: typing.Optional[typing.Union[bytes, str]] = None):  # type: (...) -> concurrent.futures.Future[model.PublishToIoTCoreResponse]
+        payload: typing.Optional[typing.Union[bytes, str]] = None,
+        retain: typing.Optional[bool] = None,
+        user_properties: typing.Optional[typing.List[model.UserProperty]] = None,
+        message_expiry_interval_seconds: typing.Optional[int] = None,
+        correlation_data: typing.Optional[typing.Union[bytes, str]] = None,
+        response_topic: typing.Optional[str] = None,
+        payload_format: typing.Optional[str] = None,
+        content_type: typing.Optional[str] = None):  # type: (...) -> concurrent.futures.Future[model.PublishToIoTCoreResponse]
         """
         Perform the PublishToIoTCore operation asynchronously.
 
@@ -533,8 +554,15 @@ class GreengrassCoreIPCClientV2:
             topic_name: 
             qos: QOS enum value
             payload: 
+            retain: 
+            user_properties: 
+            message_expiry_interval_seconds: 
+            correlation_data: 
+            response_topic: 
+            payload_format: PayloadFormat enum value
+            content_type: 
         """
-        request = model.PublishToIoTCoreRequest(topic_name=topic_name, qos=qos, payload=payload)
+        request = model.PublishToIoTCoreRequest(topic_name=topic_name, qos=qos, payload=payload, retain=retain, user_properties=user_properties, message_expiry_interval_seconds=message_expiry_interval_seconds, correlation_data=correlation_data, response_topic=response_topic, payload_format=payload_format, content_type=content_type)
         operation = self.client.new_publish_to_iot_core()
         write_future = operation.activate(request)
         return self.__combine_futures(write_future, operation.get_response())

--- a/awsiot/greengrasscoreipc/model.py
+++ b/awsiot/greengrasscoreipc/model.py
@@ -28,6 +28,71 @@ class GreengrassCoreIPCError(rpc.ErrorShape):
         return self._get_error_type_string() == 'client'
 
 
+class UserProperty(rpc.Shape):
+    """
+    UserProperty
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        key: 
+        value: 
+
+    Attributes:
+        key: 
+        value: 
+    """
+
+    def __init__(self, *,
+                 key: typing.Optional[str] = None,
+                 value: typing.Optional[str] = None):
+        super().__init__()
+        self.key = key  # type: typing.Optional[str]
+        self.value = value  # type: typing.Optional[str]
+
+    def set_key(self, key: str):
+        self.key = key
+        return self
+
+    def set_value(self, value: str):
+        self.value = value
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.key is not None:
+            payload['key'] = self.key
+        if self.value is not None:
+            payload['value'] = self.value
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'key' in payload:
+            new.key = payload['key']
+        if 'value' in payload:
+            new.value = payload['value']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#UserProperty'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
 class SystemResourceLimits(rpc.Shape):
     """
     SystemResourceLimits
@@ -35,12 +100,12 @@ class SystemResourceLimits(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        memory: 
-        cpus: 
+        memory: (Optional) The maximum amount of RAM (in kilobytes) that this component's processes can use on the core device.
+        cpus: (Optional) The maximum amount of CPU time that this component's processes can use on the core device.
 
     Attributes:
-        memory: 
-        cpus: 
+        memory: (Optional) The maximum amount of RAM (in kilobytes) that this component's processes can use on the core device.
+        cpus: (Optional) The maximum amount of CPU time that this component's processes can use on the core device.
     """
 
     def __init__(self, *,
@@ -93,17 +158,30 @@ class SystemResourceLimits(rpc.Shape):
         return False
 
 
-class MetricUnitType:
+class DeploymentStatus:
     """
-    MetricUnitType enum
+    DeploymentStatus enum
     """
 
-    BYTES = 'BYTES'
-    BYTES_PER_SECOND = 'BYTES_PER_SECOND'
-    COUNT = 'COUNT'
-    COUNT_PER_SECOND = 'COUNT_PER_SECOND'
-    MEGABYTES = 'MEGABYTES'
-    SECONDS = 'SECONDS'
+    QUEUED = 'QUEUED'
+    IN_PROGRESS = 'IN_PROGRESS'
+    SUCCEEDED = 'SUCCEEDED'
+    FAILED = 'FAILED'
+
+
+class LifecycleState:
+    """
+    LifecycleState enum
+    """
+
+    RUNNING = 'RUNNING'
+    ERRORED = 'ERRORED'
+    NEW = 'NEW'
+    FINISHED = 'FINISHED'
+    INSTALLED = 'INSTALLED'
+    BROKEN = 'BROKEN'
+    STARTING = 'STARTING'
+    STOPPING = 'STOPPING'
 
 
 class MessageContext(rpc.Shape):
@@ -113,10 +191,10 @@ class MessageContext(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        topic: 
+        topic: The topic where the message was published.
 
     Attributes:
-        topic: 
+        topic: The topic where the message was published.
     """
 
     def __init__(self, *,
@@ -159,69 +237,26 @@ class MessageContext(rpc.Shape):
         return False
 
 
-class ValidateConfigurationUpdateEvent(rpc.Shape):
+class MetricUnitType:
     """
-    ValidateConfigurationUpdateEvent
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        configuration: 
-        deployment_id: 
-
-    Attributes:
-        configuration: 
-        deployment_id: 
+    MetricUnitType enum
     """
 
-    def __init__(self, *,
-                 configuration: typing.Optional[typing.Dict[str, typing.Any]] = None,
-                 deployment_id: typing.Optional[str] = None):
-        super().__init__()
-        self.configuration = configuration  # type: typing.Optional[typing.Dict[str, typing.Any]]
-        self.deployment_id = deployment_id  # type: typing.Optional[str]
-
-    def set_configuration(self, configuration: typing.Dict[str, typing.Any]):
-        self.configuration = configuration
-        return self
-
-    def set_deployment_id(self, deployment_id: str):
-        self.deployment_id = deployment_id
-        return self
+    BYTES = 'BYTES'
+    BYTES_PER_SECOND = 'BYTES_PER_SECOND'
+    COUNT = 'COUNT'
+    COUNT_PER_SECOND = 'COUNT_PER_SECOND'
+    MEGABYTES = 'MEGABYTES'
+    SECONDS = 'SECONDS'
 
 
-    def _to_payload(self):
-        payload = {}
-        if self.configuration is not None:
-            payload['configuration'] = self.configuration
-        if self.deployment_id is not None:
-            payload['deploymentId'] = self.deployment_id
-        return payload
+class PayloadFormat:
+    """
+    PayloadFormat enum
+    """
 
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'configuration' in payload:
-            new.configuration = payload['configuration']
-        if 'deploymentId' in payload:
-            new.deployment_id = payload['deploymentId']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#ValidateConfigurationUpdateEvent'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
+    BYTES = '0'
+    UTF8 = '1'
 
 
 class RunWithInfo(rpc.Shape):
@@ -231,14 +266,14 @@ class RunWithInfo(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        posix_user: 
-        windows_user: 
-        system_resource_limits: 
+        posix_user: (Optional) The POSIX system user and, optionally, group to use to run this component on Linux core devices.
+        windows_user: (Optional) The Windows user to use to run this component on Windows core devices.
+        system_resource_limits: (Optional) The system resource limits to apply to this component's processes.
 
     Attributes:
-        posix_user: 
-        windows_user: 
-        system_resource_limits: 
+        posix_user: (Optional) The POSIX system user and, optionally, group to use to run this component on Linux core devices.
+        windows_user: (Optional) The Windows user to use to run this component on Windows core devices.
+        system_resource_limits: (Optional) The system resource limits to apply to this component's processes.
     """
 
     def __init__(self, *,
@@ -301,6 +336,124 @@ class RunWithInfo(rpc.Shape):
         return False
 
 
+class LocalDeployment(rpc.Shape):
+    """
+    LocalDeployment
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        deployment_id: The ID of the local deployment.
+        status: DeploymentStatus enum value. The status of the local deployment.
+
+    Attributes:
+        deployment_id: The ID of the local deployment.
+        status: DeploymentStatus enum value. The status of the local deployment.
+    """
+
+    def __init__(self, *,
+                 deployment_id: typing.Optional[str] = None,
+                 status: typing.Optional[str] = None):
+        super().__init__()
+        self.deployment_id = deployment_id  # type: typing.Optional[str]
+        self.status = status  # type: typing.Optional[str]
+
+    def set_deployment_id(self, deployment_id: str):
+        self.deployment_id = deployment_id
+        return self
+
+    def set_status(self, status: str):
+        self.status = status
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.deployment_id is not None:
+            payload['deploymentId'] = self.deployment_id
+        if self.status is not None:
+            payload['status'] = self.status
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'deploymentId' in payload:
+            new.deployment_id = payload['deploymentId']
+        if 'status' in payload:
+            new.status = payload['status']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#LocalDeployment'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class PostComponentUpdateEvent(rpc.Shape):
+    """
+    PostComponentUpdateEvent
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        deployment_id: The ID of the AWS IoT Greengrass deployment that updated the component.
+
+    Attributes:
+        deployment_id: The ID of the AWS IoT Greengrass deployment that updated the component.
+    """
+
+    def __init__(self, *,
+                 deployment_id: typing.Optional[str] = None):
+        super().__init__()
+        self.deployment_id = deployment_id  # type: typing.Optional[str]
+
+    def set_deployment_id(self, deployment_id: str):
+        self.deployment_id = deployment_id
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.deployment_id is not None:
+            payload['deploymentId'] = self.deployment_id
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'deploymentId' in payload:
+            new.deployment_id = payload['deploymentId']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#PostComponentUpdateEvent'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
 class PreComponentUpdateEvent(rpc.Shape):
     """
     PreComponentUpdateEvent
@@ -308,12 +461,12 @@ class PreComponentUpdateEvent(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        deployment_id: 
-        is_ggc_restarting: 
+        deployment_id: The ID of the AWS IoT Greengrass deployment that updates the component.
+        is_ggc_restarting: Whether or not Greengrass needs to restart to apply the update.
 
     Attributes:
-        deployment_id: 
-        is_ggc_restarting: 
+        deployment_id: The ID of the AWS IoT Greengrass deployment that updates the component.
+        is_ggc_restarting: Whether or not Greengrass needs to restart to apply the update.
     """
 
     def __init__(self, *,
@@ -366,385 +519,6 @@ class PreComponentUpdateEvent(rpc.Shape):
         return False
 
 
-class PostComponentUpdateEvent(rpc.Shape):
-    """
-    PostComponentUpdateEvent
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        deployment_id: 
-
-    Attributes:
-        deployment_id: 
-    """
-
-    def __init__(self, *,
-                 deployment_id: typing.Optional[str] = None):
-        super().__init__()
-        self.deployment_id = deployment_id  # type: typing.Optional[str]
-
-    def set_deployment_id(self, deployment_id: str):
-        self.deployment_id = deployment_id
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.deployment_id is not None:
-            payload['deploymentId'] = self.deployment_id
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'deploymentId' in payload:
-            new.deployment_id = payload['deploymentId']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#PostComponentUpdateEvent'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class MQTTMessage(rpc.Shape):
-    """
-    MQTTMessage
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        topic_name: 
-        payload: 
-
-    Attributes:
-        topic_name: 
-        payload: 
-    """
-
-    def __init__(self, *,
-                 topic_name: typing.Optional[str] = None,
-                 payload: typing.Optional[typing.Union[bytes, str]] = None):
-        super().__init__()
-        self.topic_name = topic_name  # type: typing.Optional[str]
-        if payload is not None and isinstance(payload, str):
-            payload = payload.encode('utf-8')
-        self.payload = payload  # type: typing.Optional[bytes]
-
-    def set_topic_name(self, topic_name: str):
-        self.topic_name = topic_name
-        return self
-
-    def set_payload(self, payload: typing.Union[bytes, str]):
-        if payload is not None and isinstance(payload, str):
-            payload = payload.encode('utf-8')
-        self.payload = payload
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.topic_name is not None:
-            payload['topicName'] = self.topic_name
-        if self.payload is not None:
-            payload['payload'] = base64.b64encode(self.payload).decode()
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'topicName' in payload:
-            new.topic_name = payload['topicName']
-        if 'payload' in payload:
-            new.payload = base64.b64decode(payload['payload'])
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#MQTTMessage'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class MQTTCredential(rpc.Shape):
-    """
-    MQTTCredential
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        client_id: 
-        certificate_pem: 
-        username: 
-        password: 
-
-    Attributes:
-        client_id: 
-        certificate_pem: 
-        username: 
-        password: 
-    """
-
-    def __init__(self, *,
-                 client_id: typing.Optional[str] = None,
-                 certificate_pem: typing.Optional[str] = None,
-                 username: typing.Optional[str] = None,
-                 password: typing.Optional[str] = None):
-        super().__init__()
-        self.client_id = client_id  # type: typing.Optional[str]
-        self.certificate_pem = certificate_pem  # type: typing.Optional[str]
-        self.username = username  # type: typing.Optional[str]
-        self.password = password  # type: typing.Optional[str]
-
-    def set_client_id(self, client_id: str):
-        self.client_id = client_id
-        return self
-
-    def set_certificate_pem(self, certificate_pem: str):
-        self.certificate_pem = certificate_pem
-        return self
-
-    def set_username(self, username: str):
-        self.username = username
-        return self
-
-    def set_password(self, password: str):
-        self.password = password
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.client_id is not None:
-            payload['clientId'] = self.client_id
-        if self.certificate_pem is not None:
-            payload['certificatePem'] = self.certificate_pem
-        if self.username is not None:
-            payload['username'] = self.username
-        if self.password is not None:
-            payload['password'] = self.password
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'clientId' in payload:
-            new.client_id = payload['clientId']
-        if 'certificatePem' in payload:
-            new.certificate_pem = payload['certificatePem']
-        if 'username' in payload:
-            new.username = payload['username']
-        if 'password' in payload:
-            new.password = payload['password']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#MQTTCredential'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class Metric(rpc.Shape):
-    """
-    Metric
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        name: 
-        unit: MetricUnitType enum value
-        value: 
-
-    Attributes:
-        name: 
-        unit: MetricUnitType enum value
-        value: 
-    """
-
-    def __init__(self, *,
-                 name: typing.Optional[str] = None,
-                 unit: typing.Optional[str] = None,
-                 value: typing.Optional[float] = None):
-        super().__init__()
-        self.name = name  # type: typing.Optional[str]
-        self.unit = unit  # type: typing.Optional[str]
-        self.value = value  # type: typing.Optional[float]
-
-    def set_name(self, name: str):
-        self.name = name
-        return self
-
-    def set_unit(self, unit: str):
-        self.unit = unit
-        return self
-
-    def set_value(self, value: float):
-        self.value = value
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.name is not None:
-            payload['name'] = self.name
-        if self.unit is not None:
-            payload['unit'] = self.unit
-        if self.value is not None:
-            payload['value'] = self.value
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'name' in payload:
-            new.name = payload['name']
-        if 'unit' in payload:
-            new.unit = payload['unit']
-        if 'value' in payload:
-            new.value = float(payload['value'])
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#Metric'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class LifecycleState:
-    """
-    LifecycleState enum
-    """
-
-    RUNNING = 'RUNNING'
-    ERRORED = 'ERRORED'
-    NEW = 'NEW'
-    FINISHED = 'FINISHED'
-    INSTALLED = 'INSTALLED'
-    BROKEN = 'BROKEN'
-    STARTING = 'STARTING'
-    STOPPING = 'STOPPING'
-
-
-class JsonMessage(rpc.Shape):
-    """
-    JsonMessage
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        message: 
-        context: The context is ignored if used in PublishMessage.
-
-    Attributes:
-        message: 
-        context: The context is ignored if used in PublishMessage.
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[typing.Dict[str, typing.Any]] = None,
-                 context: typing.Optional[MessageContext] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[typing.Dict[str, typing.Any]]
-        self.context = context  # type: typing.Optional[MessageContext]
-
-    def set_message(self, message: typing.Dict[str, typing.Any]):
-        self.message = message
-        return self
-
-    def set_context(self, context: MessageContext):
-        self.context = context
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message
-        if self.context is not None:
-            payload['context'] = self.context._to_payload()
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = payload['message']
-        if 'context' in payload:
-            new.context = MessageContext._from_payload(payload['context'])
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#JsonMessage'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class DeploymentStatus:
-    """
-    DeploymentStatus enum
-    """
-
-    QUEUED = 'QUEUED'
-    IN_PROGRESS = 'IN_PROGRESS'
-    SUCCEEDED = 'SUCCEEDED'
-    FAILED = 'FAILED'
-
-
 class ConfigurationValidityStatus:
     """
     ConfigurationValidityStatus enum
@@ -754,34 +528,50 @@ class ConfigurationValidityStatus:
     REJECTED = 'REJECTED'
 
 
-class ConfigurationUpdateEvent(rpc.Shape):
+class ComponentDetails(rpc.Shape):
     """
-    ConfigurationUpdateEvent
+    ComponentDetails
 
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
-        key_path: 
+        component_name: The name of the component.
+        version: The version of the component.
+        state: LifecycleState enum value. The state of the component.
+        configuration: The component's configuration as a JSON object.
 
     Attributes:
-        component_name: 
-        key_path: 
+        component_name: The name of the component.
+        version: The version of the component.
+        state: LifecycleState enum value. The state of the component.
+        configuration: The component's configuration as a JSON object.
     """
 
     def __init__(self, *,
                  component_name: typing.Optional[str] = None,
-                 key_path: typing.Optional[typing.List[str]] = None):
+                 version: typing.Optional[str] = None,
+                 state: typing.Optional[str] = None,
+                 configuration: typing.Optional[typing.Dict[str, typing.Any]] = None):
         super().__init__()
         self.component_name = component_name  # type: typing.Optional[str]
-        self.key_path = key_path  # type: typing.Optional[typing.List[str]]
+        self.version = version  # type: typing.Optional[str]
+        self.state = state  # type: typing.Optional[str]
+        self.configuration = configuration  # type: typing.Optional[typing.Dict[str, typing.Any]]
 
     def set_component_name(self, component_name: str):
         self.component_name = component_name
         return self
 
-    def set_key_path(self, key_path: typing.List[str]):
-        self.key_path = key_path
+    def set_version(self, version: str):
+        self.version = version
+        return self
+
+    def set_state(self, state: str):
+        self.state = state
+        return self
+
+    def set_configuration(self, configuration: typing.Dict[str, typing.Any]):
+        self.configuration = configuration
         return self
 
 
@@ -789,8 +579,12 @@ class ConfigurationUpdateEvent(rpc.Shape):
         payload = {}
         if self.component_name is not None:
             payload['componentName'] = self.component_name
-        if self.key_path is not None:
-            payload['keyPath'] = self.key_path
+        if self.version is not None:
+            payload['version'] = self.version
+        if self.state is not None:
+            payload['state'] = self.state
+        if self.configuration is not None:
+            payload['configuration'] = self.configuration
         return payload
 
     @classmethod
@@ -798,13 +592,17 @@ class ConfigurationUpdateEvent(rpc.Shape):
         new = cls()
         if 'componentName' in payload:
             new.component_name = payload['componentName']
-        if 'keyPath' in payload:
-            new.key_path = payload['keyPath']
+        if 'version' in payload:
+            new.version = payload['version']
+        if 'state' in payload:
+            new.state = payload['state']
+        if 'configuration' in payload:
+            new.configuration = payload['configuration']
         return new
 
     @classmethod
     def _model_name(cls):
-        return 'aws.greengrass#ConfigurationUpdateEvent'
+        return 'aws.greengrass#ComponentDetails'
 
     def __repr__(self):
         attrs = []
@@ -826,16 +624,16 @@ class CertificateUpdate(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        private_key: 
-        public_key: 
-        certificate: 
-        ca_certificates: 
+        private_key: The private key in pem format.
+        public_key: The public key in pem format.
+        certificate: The certificate in pem format.
+        ca_certificates: List of CA certificates in pem format.
 
     Attributes:
-        private_key: 
-        public_key: 
-        certificate: 
-        ca_certificates: 
+        private_key: The private key in pem format.
+        public_key: The public key in pem format.
+        certificate: The certificate in pem format.
+        ca_certificates: List of CA certificates in pem format.
     """
 
     def __init__(self, *,
@@ -923,12 +721,12 @@ class BinaryMessage(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        message: 
-        context: The context is ignored if used in PublishMessage.
+        message: The binary message as a blob.
+        context: The context of the message, such as the topic where the message was published.
 
     Attributes:
-        message: 
-        context: The context is ignored if used in PublishMessage.
+        message: The binary message as a blob.
+        context: The context of the message, such as the topic where the message was published.
     """
 
     def __init__(self, *,
@@ -985,47 +783,57 @@ class BinaryMessage(rpc.Shape):
         return False
 
 
-class ValidateConfigurationUpdateEvents(rpc.Shape):
+class JsonMessage(rpc.Shape):
     """
-    ValidateConfigurationUpdateEvents is a "tagged union" class.
+    JsonMessage
 
-    When sending, only one of the attributes may be set.
-    When receiving, only one of the attributes will be set.
-    All other attributes will be None.
+    All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        validate_configuration_update_event: 
+        message: The JSON message as an object.
+        context: The context of the message, such as the topic where the message was published.
 
     Attributes:
-        validate_configuration_update_event: 
+        message: The JSON message as an object.
+        context: The context of the message, such as the topic where the message was published.
     """
 
     def __init__(self, *,
-                 validate_configuration_update_event: typing.Optional[ValidateConfigurationUpdateEvent] = None):
+                 message: typing.Optional[typing.Dict[str, typing.Any]] = None,
+                 context: typing.Optional[MessageContext] = None):
         super().__init__()
-        self.validate_configuration_update_event = validate_configuration_update_event  # type: typing.Optional[ValidateConfigurationUpdateEvent]
+        self.message = message  # type: typing.Optional[typing.Dict[str, typing.Any]]
+        self.context = context  # type: typing.Optional[MessageContext]
 
-    def set_validate_configuration_update_event(self, validate_configuration_update_event: ValidateConfigurationUpdateEvent):
-        self.validate_configuration_update_event = validate_configuration_update_event
+    def set_message(self, message: typing.Dict[str, typing.Any]):
+        self.message = message
+        return self
+
+    def set_context(self, context: MessageContext):
+        self.context = context
         return self
 
 
     def _to_payload(self):
         payload = {}
-        if self.validate_configuration_update_event is not None:
-            payload['validateConfigurationUpdateEvent'] = self.validate_configuration_update_event._to_payload()
+        if self.message is not None:
+            payload['message'] = self.message
+        if self.context is not None:
+            payload['context'] = self.context._to_payload()
         return payload
 
     @classmethod
     def _from_payload(cls, payload):
         new = cls()
-        if 'validateConfigurationUpdateEvent' in payload:
-            new.validate_configuration_update_event = ValidateConfigurationUpdateEvent._from_payload(payload['validateConfigurationUpdateEvent'])
+        if 'message' in payload:
+            new.message = payload['message']
+        if 'context' in payload:
+            new.context = MessageContext._from_payload(payload['context'])
         return new
 
     @classmethod
     def _model_name(cls):
-        return 'aws.greengrass#ValidateConfigurationUpdateEvents'
+        return 'aws.greengrass#JsonMessage'
 
     def __repr__(self):
         attrs = []
@@ -1040,59 +848,81 @@ class ValidateConfigurationUpdateEvents(rpc.Shape):
         return False
 
 
-class SubscriptionResponseMessage(rpc.Shape):
+class MQTTCredential(rpc.Shape):
     """
-    SubscriptionResponseMessage is a "tagged union" class.
+    MQTTCredential
 
-    When sending, only one of the attributes may be set.
-    When receiving, only one of the attributes will be set.
-    All other attributes will be None.
+    All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        json_message: 
-        binary_message: 
+        client_id: The client ID to used to connect.
+        certificate_pem: The client certificate in pem format.
+        username: The username. (unused).
+        password: The password. (unused).
 
     Attributes:
-        json_message: 
-        binary_message: 
+        client_id: The client ID to used to connect.
+        certificate_pem: The client certificate in pem format.
+        username: The username. (unused).
+        password: The password. (unused).
     """
 
     def __init__(self, *,
-                 json_message: typing.Optional[JsonMessage] = None,
-                 binary_message: typing.Optional[BinaryMessage] = None):
+                 client_id: typing.Optional[str] = None,
+                 certificate_pem: typing.Optional[str] = None,
+                 username: typing.Optional[str] = None,
+                 password: typing.Optional[str] = None):
         super().__init__()
-        self.json_message = json_message  # type: typing.Optional[JsonMessage]
-        self.binary_message = binary_message  # type: typing.Optional[BinaryMessage]
+        self.client_id = client_id  # type: typing.Optional[str]
+        self.certificate_pem = certificate_pem  # type: typing.Optional[str]
+        self.username = username  # type: typing.Optional[str]
+        self.password = password  # type: typing.Optional[str]
 
-    def set_json_message(self, json_message: JsonMessage):
-        self.json_message = json_message
+    def set_client_id(self, client_id: str):
+        self.client_id = client_id
         return self
 
-    def set_binary_message(self, binary_message: BinaryMessage):
-        self.binary_message = binary_message
+    def set_certificate_pem(self, certificate_pem: str):
+        self.certificate_pem = certificate_pem
+        return self
+
+    def set_username(self, username: str):
+        self.username = username
+        return self
+
+    def set_password(self, password: str):
+        self.password = password
         return self
 
 
     def _to_payload(self):
         payload = {}
-        if self.json_message is not None:
-            payload['jsonMessage'] = self.json_message._to_payload()
-        if self.binary_message is not None:
-            payload['binaryMessage'] = self.binary_message._to_payload()
+        if self.client_id is not None:
+            payload['clientId'] = self.client_id
+        if self.certificate_pem is not None:
+            payload['certificatePem'] = self.certificate_pem
+        if self.username is not None:
+            payload['username'] = self.username
+        if self.password is not None:
+            payload['password'] = self.password
         return payload
 
     @classmethod
     def _from_payload(cls, payload):
         new = cls()
-        if 'jsonMessage' in payload:
-            new.json_message = JsonMessage._from_payload(payload['jsonMessage'])
-        if 'binaryMessage' in payload:
-            new.binary_message = BinaryMessage._from_payload(payload['binaryMessage'])
+        if 'clientId' in payload:
+            new.client_id = payload['clientId']
+        if 'certificatePem' in payload:
+            new.certificate_pem = payload['certificatePem']
+        if 'username' in payload:
+            new.username = payload['username']
+        if 'password' in payload:
+            new.password = payload['password']
         return new
 
     @classmethod
     def _model_name(cls):
-        return 'aws.greengrass#SubscriptionResponseMessage'
+        return 'aws.greengrass#MQTTCredential'
 
     def __repr__(self):
         attrs = []
@@ -1105,6 +935,455 @@ class SubscriptionResponseMessage(rpc.Shape):
         if isinstance(other, self.__class__):
             return self.__dict__ == other.__dict__
         return False
+
+
+class ValidateConfigurationUpdateEvent(rpc.Shape):
+    """
+    ValidateConfigurationUpdateEvent
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        configuration: The object that contains the new configuration.
+        deployment_id: The ID of the AWS IoT Greengrass deployment that updates the component.
+
+    Attributes:
+        configuration: The object that contains the new configuration.
+        deployment_id: The ID of the AWS IoT Greengrass deployment that updates the component.
+    """
+
+    def __init__(self, *,
+                 configuration: typing.Optional[typing.Dict[str, typing.Any]] = None,
+                 deployment_id: typing.Optional[str] = None):
+        super().__init__()
+        self.configuration = configuration  # type: typing.Optional[typing.Dict[str, typing.Any]]
+        self.deployment_id = deployment_id  # type: typing.Optional[str]
+
+    def set_configuration(self, configuration: typing.Dict[str, typing.Any]):
+        self.configuration = configuration
+        return self
+
+    def set_deployment_id(self, deployment_id: str):
+        self.deployment_id = deployment_id
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.configuration is not None:
+            payload['configuration'] = self.configuration
+        if self.deployment_id is not None:
+            payload['deploymentId'] = self.deployment_id
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'configuration' in payload:
+            new.configuration = payload['configuration']
+        if 'deploymentId' in payload:
+            new.deployment_id = payload['deploymentId']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ValidateConfigurationUpdateEvent'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class Metric(rpc.Shape):
+    """
+    Metric
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        name: 
+        unit: MetricUnitType enum value. 
+        value: 
+
+    Attributes:
+        name: 
+        unit: MetricUnitType enum value. 
+        value: 
+    """
+
+    def __init__(self, *,
+                 name: typing.Optional[str] = None,
+                 unit: typing.Optional[str] = None,
+                 value: typing.Optional[float] = None):
+        super().__init__()
+        self.name = name  # type: typing.Optional[str]
+        self.unit = unit  # type: typing.Optional[str]
+        self.value = value  # type: typing.Optional[float]
+
+    def set_name(self, name: str):
+        self.name = name
+        return self
+
+    def set_unit(self, unit: str):
+        self.unit = unit
+        return self
+
+    def set_value(self, value: float):
+        self.value = value
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.name is not None:
+            payload['name'] = self.name
+        if self.unit is not None:
+            payload['unit'] = self.unit
+        if self.value is not None:
+            payload['value'] = self.value
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'name' in payload:
+            new.name = payload['name']
+        if 'unit' in payload:
+            new.unit = payload['unit']
+        if 'value' in payload:
+            new.value = float(payload['value'])
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#Metric'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class ConfigurationUpdateEvent(rpc.Shape):
+    """
+    ConfigurationUpdateEvent
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        component_name: The name of the component.
+        key_path: The key path to the configuration value that updated.
+
+    Attributes:
+        component_name: The name of the component.
+        key_path: The key path to the configuration value that updated.
+    """
+
+    def __init__(self, *,
+                 component_name: typing.Optional[str] = None,
+                 key_path: typing.Optional[typing.List[str]] = None):
+        super().__init__()
+        self.component_name = component_name  # type: typing.Optional[str]
+        self.key_path = key_path  # type: typing.Optional[typing.List[str]]
+
+    def set_component_name(self, component_name: str):
+        self.component_name = component_name
+        return self
+
+    def set_key_path(self, key_path: typing.List[str]):
+        self.key_path = key_path
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.component_name is not None:
+            payload['componentName'] = self.component_name
+        if self.key_path is not None:
+            payload['keyPath'] = self.key_path
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'componentName' in payload:
+            new.component_name = payload['componentName']
+        if 'keyPath' in payload:
+            new.key_path = payload['keyPath']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ConfigurationUpdateEvent'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class MQTTMessage(rpc.Shape):
+    """
+    MQTTMessage
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        topic_name: The topic to which the message was published.
+        payload: (Optional) The message payload as a blob.
+        retain: (Optional) The value of the retain flag.
+        user_properties: (Optional) MQTT user properties associated with the message.
+        message_expiry_interval_seconds: (Optional) Message expiry interval in seconds.
+        correlation_data: (Optional) Correlation data blob for request/response.
+        response_topic: (Optional) Response topic for request/response.
+        payload_format: PayloadFormat enum value. (Optional) Message payload format.
+        content_type: (Optional) Message content type.
+
+    Attributes:
+        topic_name: The topic to which the message was published.
+        payload: (Optional) The message payload as a blob.
+        retain: (Optional) The value of the retain flag.
+        user_properties: (Optional) MQTT user properties associated with the message.
+        message_expiry_interval_seconds: (Optional) Message expiry interval in seconds.
+        correlation_data: (Optional) Correlation data blob for request/response.
+        response_topic: (Optional) Response topic for request/response.
+        payload_format: PayloadFormat enum value. (Optional) Message payload format.
+        content_type: (Optional) Message content type.
+    """
+
+    def __init__(self, *,
+                 topic_name: typing.Optional[str] = None,
+                 payload: typing.Optional[typing.Union[bytes, str]] = None,
+                 retain: typing.Optional[bool] = None,
+                 user_properties: typing.Optional[typing.List[UserProperty]] = None,
+                 message_expiry_interval_seconds: typing.Optional[int] = None,
+                 correlation_data: typing.Optional[typing.Union[bytes, str]] = None,
+                 response_topic: typing.Optional[str] = None,
+                 payload_format: typing.Optional[str] = None,
+                 content_type: typing.Optional[str] = None):
+        super().__init__()
+        self.topic_name = topic_name  # type: typing.Optional[str]
+        if payload is not None and isinstance(payload, str):
+            payload = payload.encode('utf-8')
+        self.payload = payload  # type: typing.Optional[bytes]
+        self.retain = retain  # type: typing.Optional[bool]
+        self.user_properties = user_properties  # type: typing.Optional[typing.List[UserProperty]]
+        self.message_expiry_interval_seconds = message_expiry_interval_seconds  # type: typing.Optional[int]
+        if correlation_data is not None and isinstance(correlation_data, str):
+            correlation_data = correlation_data.encode('utf-8')
+        self.correlation_data = correlation_data  # type: typing.Optional[bytes]
+        self.response_topic = response_topic  # type: typing.Optional[str]
+        self.payload_format = payload_format  # type: typing.Optional[str]
+        self.content_type = content_type  # type: typing.Optional[str]
+
+    def set_topic_name(self, topic_name: str):
+        self.topic_name = topic_name
+        return self
+
+    def set_payload(self, payload: typing.Union[bytes, str]):
+        if payload is not None and isinstance(payload, str):
+            payload = payload.encode('utf-8')
+        self.payload = payload
+        return self
+
+    def set_retain(self, retain: bool):
+        self.retain = retain
+        return self
+
+    def set_user_properties(self, user_properties: typing.List[UserProperty]):
+        self.user_properties = user_properties
+        return self
+
+    def set_message_expiry_interval_seconds(self, message_expiry_interval_seconds: int):
+        self.message_expiry_interval_seconds = message_expiry_interval_seconds
+        return self
+
+    def set_correlation_data(self, correlation_data: typing.Union[bytes, str]):
+        if correlation_data is not None and isinstance(correlation_data, str):
+            correlation_data = correlation_data.encode('utf-8')
+        self.correlation_data = correlation_data
+        return self
+
+    def set_response_topic(self, response_topic: str):
+        self.response_topic = response_topic
+        return self
+
+    def set_payload_format(self, payload_format: str):
+        self.payload_format = payload_format
+        return self
+
+    def set_content_type(self, content_type: str):
+        self.content_type = content_type
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.topic_name is not None:
+            payload['topicName'] = self.topic_name
+        if self.payload is not None:
+            payload['payload'] = base64.b64encode(self.payload).decode()
+        if self.retain is not None:
+            payload['retain'] = self.retain
+        if self.user_properties is not None:
+            payload['userProperties'] = [i._to_payload() for i in self.user_properties]
+        if self.message_expiry_interval_seconds is not None:
+            payload['messageExpiryIntervalSeconds'] = self.message_expiry_interval_seconds
+        if self.correlation_data is not None:
+            payload['correlationData'] = base64.b64encode(self.correlation_data).decode()
+        if self.response_topic is not None:
+            payload['responseTopic'] = self.response_topic
+        if self.payload_format is not None:
+            payload['payloadFormat'] = self.payload_format
+        if self.content_type is not None:
+            payload['contentType'] = self.content_type
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'topicName' in payload:
+            new.topic_name = payload['topicName']
+        if 'payload' in payload:
+            new.payload = base64.b64decode(payload['payload'])
+        if 'retain' in payload:
+            new.retain = payload['retain']
+        if 'userProperties' in payload:
+            new.user_properties = [UserProperty._from_payload(i) for i in payload['userProperties']]
+        if 'messageExpiryIntervalSeconds' in payload:
+            new.message_expiry_interval_seconds = int(payload['messageExpiryIntervalSeconds'])
+        if 'correlationData' in payload:
+            new.correlation_data = base64.b64decode(payload['correlationData'])
+        if 'responseTopic' in payload:
+            new.response_topic = payload['responseTopic']
+        if 'payloadFormat' in payload:
+            new.payload_format = payload['payloadFormat']
+        if 'contentType' in payload:
+            new.content_type = payload['contentType']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#MQTTMessage'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class RequestStatus:
+    """
+    RequestStatus enum
+    """
+
+    SUCCEEDED = 'SUCCEEDED'
+    FAILED = 'FAILED'
+
+
+class ComponentUpdatePolicyEvents(rpc.Shape):
+    """
+    ComponentUpdatePolicyEvents is a "tagged union" class.
+
+    When sending, only one of the attributes may be set.
+    When receiving, only one of the attributes will be set.
+    All other attributes will be None.
+
+    Keyword Args:
+        pre_update_event: An event that indicates that the Greengrass wants to update a component.
+        post_update_event: An event that indicates that the nucleus updated a component.
+
+    Attributes:
+        pre_update_event: An event that indicates that the Greengrass wants to update a component.
+        post_update_event: An event that indicates that the nucleus updated a component.
+    """
+
+    def __init__(self, *,
+                 pre_update_event: typing.Optional[PreComponentUpdateEvent] = None,
+                 post_update_event: typing.Optional[PostComponentUpdateEvent] = None):
+        super().__init__()
+        self.pre_update_event = pre_update_event  # type: typing.Optional[PreComponentUpdateEvent]
+        self.post_update_event = post_update_event  # type: typing.Optional[PostComponentUpdateEvent]
+
+    def set_pre_update_event(self, pre_update_event: PreComponentUpdateEvent):
+        self.pre_update_event = pre_update_event
+        return self
+
+    def set_post_update_event(self, post_update_event: PostComponentUpdateEvent):
+        self.post_update_event = post_update_event
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.pre_update_event is not None:
+            payload['preUpdateEvent'] = self.pre_update_event._to_payload()
+        if self.post_update_event is not None:
+            payload['postUpdateEvent'] = self.post_update_event._to_payload()
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'preUpdateEvent' in payload:
+            new.pre_update_event = PreComponentUpdateEvent._from_payload(payload['preUpdateEvent'])
+        if 'postUpdateEvent' in payload:
+            new.post_update_event = PostComponentUpdateEvent._from_payload(payload['postUpdateEvent'])
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ComponentUpdatePolicyEvents'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class ReportedLifecycleState:
+    """
+    ReportedLifecycleState enum
+    """
+
+    RUNNING = 'RUNNING'
+    ERRORED = 'ERRORED'
 
 
 class SecretValue(rpc.Shape):
@@ -1116,12 +1395,12 @@ class SecretValue(rpc.Shape):
     All other attributes will be None.
 
     Keyword Args:
-        secret_string: 
-        secret_binary: 
+        secret_string: The decrypted part of the protected secret information that you provided to Secrets Manager as a string.
+        secret_binary: (Optional) The decrypted part of the protected secret information that you provided to Secrets Manager as binary data in the form of a byte array.
 
     Attributes:
-        secret_string: 
-        secret_binary: 
+        secret_string: The decrypted part of the protected secret information that you provided to Secrets Manager as a string.
+        secret_binary: (Optional) The decrypted part of the protected secret information that you provided to Secrets Manager as binary data in the form of a byte array.
     """
 
     def __init__(self, *,
@@ -1178,284 +1457,6 @@ class SecretValue(rpc.Shape):
         return False
 
 
-class RequestStatus:
-    """
-    RequestStatus enum
-    """
-
-    SUCCEEDED = 'SUCCEEDED'
-    FAILED = 'FAILED'
-
-
-class ReportedLifecycleState:
-    """
-    ReportedLifecycleState enum
-    """
-
-    RUNNING = 'RUNNING'
-    ERRORED = 'ERRORED'
-
-
-class ReceiveMode:
-    """
-    ReceiveMode enum
-    """
-
-    RECEIVE_ALL_MESSAGES = 'RECEIVE_ALL_MESSAGES'
-    RECEIVE_MESSAGES_FROM_OTHERS = 'RECEIVE_MESSAGES_FROM_OTHERS'
-
-
-class QOS:
-    """
-    QOS enum
-    """
-
-    AT_MOST_ONCE = '0'
-    AT_LEAST_ONCE = '1'
-
-
-class PublishMessage(rpc.Shape):
-    """
-    PublishMessage is a "tagged union" class.
-
-    When sending, only one of the attributes may be set.
-    When receiving, only one of the attributes will be set.
-    All other attributes will be None.
-
-    Keyword Args:
-        json_message: 
-        binary_message: 
-
-    Attributes:
-        json_message: 
-        binary_message: 
-    """
-
-    def __init__(self, *,
-                 json_message: typing.Optional[JsonMessage] = None,
-                 binary_message: typing.Optional[BinaryMessage] = None):
-        super().__init__()
-        self.json_message = json_message  # type: typing.Optional[JsonMessage]
-        self.binary_message = binary_message  # type: typing.Optional[BinaryMessage]
-
-    def set_json_message(self, json_message: JsonMessage):
-        self.json_message = json_message
-        return self
-
-    def set_binary_message(self, binary_message: BinaryMessage):
-        self.binary_message = binary_message
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.json_message is not None:
-            payload['jsonMessage'] = self.json_message._to_payload()
-        if self.binary_message is not None:
-            payload['binaryMessage'] = self.binary_message._to_payload()
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'jsonMessage' in payload:
-            new.json_message = JsonMessage._from_payload(payload['jsonMessage'])
-        if 'binaryMessage' in payload:
-            new.binary_message = BinaryMessage._from_payload(payload['binaryMessage'])
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#PublishMessage'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class LocalDeployment(rpc.Shape):
-    """
-    LocalDeployment
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        deployment_id: 
-        status: DeploymentStatus enum value
-
-    Attributes:
-        deployment_id: 
-        status: DeploymentStatus enum value
-    """
-
-    def __init__(self, *,
-                 deployment_id: typing.Optional[str] = None,
-                 status: typing.Optional[str] = None):
-        super().__init__()
-        self.deployment_id = deployment_id  # type: typing.Optional[str]
-        self.status = status  # type: typing.Optional[str]
-
-    def set_deployment_id(self, deployment_id: str):
-        self.deployment_id = deployment_id
-        return self
-
-    def set_status(self, status: str):
-        self.status = status
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.deployment_id is not None:
-            payload['deploymentId'] = self.deployment_id
-        if self.status is not None:
-            payload['status'] = self.status
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'deploymentId' in payload:
-            new.deployment_id = payload['deploymentId']
-        if 'status' in payload:
-            new.status = payload['status']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#LocalDeployment'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class IoTCoreMessage(rpc.Shape):
-    """
-    IoTCoreMessage is a "tagged union" class.
-
-    When sending, only one of the attributes may be set.
-    When receiving, only one of the attributes will be set.
-    All other attributes will be None.
-
-    Keyword Args:
-        message: 
-
-    Attributes:
-        message: 
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[MQTTMessage] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[MQTTMessage]
-
-    def set_message(self, message: MQTTMessage):
-        self.message = message
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message._to_payload()
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = MQTTMessage._from_payload(payload['message'])
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#IoTCoreMessage'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class CredentialDocument(rpc.Shape):
-    """
-    CredentialDocument is a "tagged union" class.
-
-    When sending, only one of the attributes may be set.
-    When receiving, only one of the attributes will be set.
-    All other attributes will be None.
-
-    Keyword Args:
-        mqtt_credential: 
-
-    Attributes:
-        mqtt_credential: 
-    """
-
-    def __init__(self, *,
-                 mqtt_credential: typing.Optional[MQTTCredential] = None):
-        super().__init__()
-        self.mqtt_credential = mqtt_credential  # type: typing.Optional[MQTTCredential]
-
-    def set_mqtt_credential(self, mqtt_credential: MQTTCredential):
-        self.mqtt_credential = mqtt_credential
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.mqtt_credential is not None:
-            payload['mqttCredential'] = self.mqtt_credential._to_payload()
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'mqttCredential' in payload:
-            new.mqtt_credential = MQTTCredential._from_payload(payload['mqttCredential'])
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#CredentialDocument'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
 class ConfigurationValidityReport(rpc.Shape):
     """
     ConfigurationValidityReport
@@ -1463,14 +1464,14 @@ class ConfigurationValidityReport(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        status: ConfigurationValidityStatus enum value
-        deployment_id: 
-        message: 
+        status: ConfigurationValidityStatus enum value. The validity status.
+        deployment_id: The ID of the AWS IoT Greengrass deployment that requested the configuration update.
+        message: (Optional) A message that reports why the configuration isn't valid.
 
     Attributes:
-        status: ConfigurationValidityStatus enum value
-        deployment_id: 
-        message: 
+        status: ConfigurationValidityStatus enum value. The validity status.
+        deployment_id: The ID of the AWS IoT Greengrass deployment that requested the configuration update.
+        message: (Optional) A message that reports why the configuration isn't valid.
     """
 
     def __init__(self, *,
@@ -1533,217 +1534,6 @@ class ConfigurationValidityReport(rpc.Shape):
         return False
 
 
-class ConfigurationUpdateEvents(rpc.Shape):
-    """
-    ConfigurationUpdateEvents is a "tagged union" class.
-
-    When sending, only one of the attributes may be set.
-    When receiving, only one of the attributes will be set.
-    All other attributes will be None.
-
-    Keyword Args:
-        configuration_update_event: 
-
-    Attributes:
-        configuration_update_event: 
-    """
-
-    def __init__(self, *,
-                 configuration_update_event: typing.Optional[ConfigurationUpdateEvent] = None):
-        super().__init__()
-        self.configuration_update_event = configuration_update_event  # type: typing.Optional[ConfigurationUpdateEvent]
-
-    def set_configuration_update_event(self, configuration_update_event: ConfigurationUpdateEvent):
-        self.configuration_update_event = configuration_update_event
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.configuration_update_event is not None:
-            payload['configurationUpdateEvent'] = self.configuration_update_event._to_payload()
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'configurationUpdateEvent' in payload:
-            new.configuration_update_event = ConfigurationUpdateEvent._from_payload(payload['configurationUpdateEvent'])
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#ConfigurationUpdateEvents'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class ComponentUpdatePolicyEvents(rpc.Shape):
-    """
-    ComponentUpdatePolicyEvents is a "tagged union" class.
-
-    When sending, only one of the attributes may be set.
-    When receiving, only one of the attributes will be set.
-    All other attributes will be None.
-
-    Keyword Args:
-        pre_update_event: 
-        post_update_event: 
-
-    Attributes:
-        pre_update_event: 
-        post_update_event: 
-    """
-
-    def __init__(self, *,
-                 pre_update_event: typing.Optional[PreComponentUpdateEvent] = None,
-                 post_update_event: typing.Optional[PostComponentUpdateEvent] = None):
-        super().__init__()
-        self.pre_update_event = pre_update_event  # type: typing.Optional[PreComponentUpdateEvent]
-        self.post_update_event = post_update_event  # type: typing.Optional[PostComponentUpdateEvent]
-
-    def set_pre_update_event(self, pre_update_event: PreComponentUpdateEvent):
-        self.pre_update_event = pre_update_event
-        return self
-
-    def set_post_update_event(self, post_update_event: PostComponentUpdateEvent):
-        self.post_update_event = post_update_event
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.pre_update_event is not None:
-            payload['preUpdateEvent'] = self.pre_update_event._to_payload()
-        if self.post_update_event is not None:
-            payload['postUpdateEvent'] = self.post_update_event._to_payload()
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'preUpdateEvent' in payload:
-            new.pre_update_event = PreComponentUpdateEvent._from_payload(payload['preUpdateEvent'])
-        if 'postUpdateEvent' in payload:
-            new.post_update_event = PostComponentUpdateEvent._from_payload(payload['postUpdateEvent'])
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#ComponentUpdatePolicyEvents'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class ComponentDetails(rpc.Shape):
-    """
-    ComponentDetails
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        component_name: 
-        version: 
-        state: LifecycleState enum value
-        configuration: 
-
-    Attributes:
-        component_name: 
-        version: 
-        state: LifecycleState enum value
-        configuration: 
-    """
-
-    def __init__(self, *,
-                 component_name: typing.Optional[str] = None,
-                 version: typing.Optional[str] = None,
-                 state: typing.Optional[str] = None,
-                 configuration: typing.Optional[typing.Dict[str, typing.Any]] = None):
-        super().__init__()
-        self.component_name = component_name  # type: typing.Optional[str]
-        self.version = version  # type: typing.Optional[str]
-        self.state = state  # type: typing.Optional[str]
-        self.configuration = configuration  # type: typing.Optional[typing.Dict[str, typing.Any]]
-
-    def set_component_name(self, component_name: str):
-        self.component_name = component_name
-        return self
-
-    def set_version(self, version: str):
-        self.version = version
-        return self
-
-    def set_state(self, state: str):
-        self.state = state
-        return self
-
-    def set_configuration(self, configuration: typing.Dict[str, typing.Any]):
-        self.configuration = configuration
-        return self
-
-
-    def _to_payload(self):
-        payload = {}
-        if self.component_name is not None:
-            payload['componentName'] = self.component_name
-        if self.version is not None:
-            payload['version'] = self.version
-        if self.state is not None:
-            payload['state'] = self.state
-        if self.configuration is not None:
-            payload['configuration'] = self.configuration
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'componentName' in payload:
-            new.component_name = payload['componentName']
-        if 'version' in payload:
-            new.version = payload['version']
-        if 'state' in payload:
-            new.state = payload['state']
-        if 'configuration' in payload:
-            new.configuration = payload['configuration']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#ComponentDetails'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
 class ClientDeviceCredential(rpc.Shape):
     """
     ClientDeviceCredential is a "tagged union" class.
@@ -1753,10 +1543,10 @@ class ClientDeviceCredential(rpc.Shape):
     All other attributes will be None.
 
     Keyword Args:
-        client_device_certificate: 
+        client_device_certificate: The client device's X.509 device certificate.
 
     Attributes:
-        client_device_certificate: 
+        client_device_certificate: The client device's X.509 device certificate.
     """
 
     def __init__(self, *,
@@ -1808,10 +1598,10 @@ class CertificateUpdateEvent(rpc.Shape):
     All other attributes will be None.
 
     Keyword Args:
-        certificate_update: 
+        certificate_update: The information about the new certificate.
 
     Attributes:
-        certificate_update: 
+        certificate_update: The information about the new certificate.
     """
 
     def __init__(self, *,
@@ -1861,10 +1651,10 @@ class CertificateOptions(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        certificate_type: CertificateType enum value
+        certificate_type: CertificateType enum value. The types of certificate updates to subscribe to.
 
     Attributes:
-        certificate_type: CertificateType enum value
+        certificate_type: CertificateType enum value. The types of certificate updates to subscribe to.
     """
 
     def __init__(self, *,
@@ -1893,6 +1683,434 @@ class CertificateOptions(rpc.Shape):
     @classmethod
     def _model_name(cls):
         return 'aws.greengrass#CertificateOptions'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class PublishMessage(rpc.Shape):
+    """
+    PublishMessage is a "tagged union" class.
+
+    When sending, only one of the attributes may be set.
+    When receiving, only one of the attributes will be set.
+    All other attributes will be None.
+
+    Keyword Args:
+        json_message: (Optional) A JSON message.
+        binary_message: (Optional) A binary message.
+
+    Attributes:
+        json_message: (Optional) A JSON message.
+        binary_message: (Optional) A binary message.
+    """
+
+    def __init__(self, *,
+                 json_message: typing.Optional[JsonMessage] = None,
+                 binary_message: typing.Optional[BinaryMessage] = None):
+        super().__init__()
+        self.json_message = json_message  # type: typing.Optional[JsonMessage]
+        self.binary_message = binary_message  # type: typing.Optional[BinaryMessage]
+
+    def set_json_message(self, json_message: JsonMessage):
+        self.json_message = json_message
+        return self
+
+    def set_binary_message(self, binary_message: BinaryMessage):
+        self.binary_message = binary_message
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.json_message is not None:
+            payload['jsonMessage'] = self.json_message._to_payload()
+        if self.binary_message is not None:
+            payload['binaryMessage'] = self.binary_message._to_payload()
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'jsonMessage' in payload:
+            new.json_message = JsonMessage._from_payload(payload['jsonMessage'])
+        if 'binaryMessage' in payload:
+            new.binary_message = BinaryMessage._from_payload(payload['binaryMessage'])
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#PublishMessage'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class CredentialDocument(rpc.Shape):
+    """
+    CredentialDocument is a "tagged union" class.
+
+    When sending, only one of the attributes may be set.
+    When receiving, only one of the attributes will be set.
+    All other attributes will be None.
+
+    Keyword Args:
+        mqtt_credential: The client device's MQTT credentials. Specify the client ID and certificate that the client device uses to connect.
+
+    Attributes:
+        mqtt_credential: The client device's MQTT credentials. Specify the client ID and certificate that the client device uses to connect.
+    """
+
+    def __init__(self, *,
+                 mqtt_credential: typing.Optional[MQTTCredential] = None):
+        super().__init__()
+        self.mqtt_credential = mqtt_credential  # type: typing.Optional[MQTTCredential]
+
+    def set_mqtt_credential(self, mqtt_credential: MQTTCredential):
+        self.mqtt_credential = mqtt_credential
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.mqtt_credential is not None:
+            payload['mqttCredential'] = self.mqtt_credential._to_payload()
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'mqttCredential' in payload:
+            new.mqtt_credential = MQTTCredential._from_payload(payload['mqttCredential'])
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#CredentialDocument'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class SubscriptionResponseMessage(rpc.Shape):
+    """
+    SubscriptionResponseMessage is a "tagged union" class.
+
+    When sending, only one of the attributes may be set.
+    When receiving, only one of the attributes will be set.
+    All other attributes will be None.
+
+    Keyword Args:
+        json_message: (Optional) A JSON message.
+        binary_message: (Optional) A binary message.
+
+    Attributes:
+        json_message: (Optional) A JSON message.
+        binary_message: (Optional) A binary message.
+    """
+
+    def __init__(self, *,
+                 json_message: typing.Optional[JsonMessage] = None,
+                 binary_message: typing.Optional[BinaryMessage] = None):
+        super().__init__()
+        self.json_message = json_message  # type: typing.Optional[JsonMessage]
+        self.binary_message = binary_message  # type: typing.Optional[BinaryMessage]
+
+    def set_json_message(self, json_message: JsonMessage):
+        self.json_message = json_message
+        return self
+
+    def set_binary_message(self, binary_message: BinaryMessage):
+        self.binary_message = binary_message
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.json_message is not None:
+            payload['jsonMessage'] = self.json_message._to_payload()
+        if self.binary_message is not None:
+            payload['binaryMessage'] = self.binary_message._to_payload()
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'jsonMessage' in payload:
+            new.json_message = JsonMessage._from_payload(payload['jsonMessage'])
+        if 'binaryMessage' in payload:
+            new.binary_message = BinaryMessage._from_payload(payload['binaryMessage'])
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#SubscriptionResponseMessage'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class ReceiveMode:
+    """
+    ReceiveMode enum
+    """
+
+    RECEIVE_ALL_MESSAGES = 'RECEIVE_ALL_MESSAGES'
+    RECEIVE_MESSAGES_FROM_OTHERS = 'RECEIVE_MESSAGES_FROM_OTHERS'
+
+
+class ValidateConfigurationUpdateEvents(rpc.Shape):
+    """
+    ValidateConfigurationUpdateEvents is a "tagged union" class.
+
+    When sending, only one of the attributes may be set.
+    When receiving, only one of the attributes will be set.
+    All other attributes will be None.
+
+    Keyword Args:
+        validate_configuration_update_event: The configuration update event.
+
+    Attributes:
+        validate_configuration_update_event: The configuration update event.
+    """
+
+    def __init__(self, *,
+                 validate_configuration_update_event: typing.Optional[ValidateConfigurationUpdateEvent] = None):
+        super().__init__()
+        self.validate_configuration_update_event = validate_configuration_update_event  # type: typing.Optional[ValidateConfigurationUpdateEvent]
+
+    def set_validate_configuration_update_event(self, validate_configuration_update_event: ValidateConfigurationUpdateEvent):
+        self.validate_configuration_update_event = validate_configuration_update_event
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.validate_configuration_update_event is not None:
+            payload['validateConfigurationUpdateEvent'] = self.validate_configuration_update_event._to_payload()
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'validateConfigurationUpdateEvent' in payload:
+            new.validate_configuration_update_event = ValidateConfigurationUpdateEvent._from_payload(payload['validateConfigurationUpdateEvent'])
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ValidateConfigurationUpdateEvents'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class ConfigurationUpdateEvents(rpc.Shape):
+    """
+    ConfigurationUpdateEvents is a "tagged union" class.
+
+    When sending, only one of the attributes may be set.
+    When receiving, only one of the attributes will be set.
+    All other attributes will be None.
+
+    Keyword Args:
+        configuration_update_event: The configuration update event.
+
+    Attributes:
+        configuration_update_event: The configuration update event.
+    """
+
+    def __init__(self, *,
+                 configuration_update_event: typing.Optional[ConfigurationUpdateEvent] = None):
+        super().__init__()
+        self.configuration_update_event = configuration_update_event  # type: typing.Optional[ConfigurationUpdateEvent]
+
+    def set_configuration_update_event(self, configuration_update_event: ConfigurationUpdateEvent):
+        self.configuration_update_event = configuration_update_event
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.configuration_update_event is not None:
+            payload['configurationUpdateEvent'] = self.configuration_update_event._to_payload()
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'configurationUpdateEvent' in payload:
+            new.configuration_update_event = ConfigurationUpdateEvent._from_payload(payload['configurationUpdateEvent'])
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ConfigurationUpdateEvents'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class QOS:
+    """
+    QOS enum
+    """
+
+    AT_MOST_ONCE = '0'
+    AT_LEAST_ONCE = '1'
+
+
+class IoTCoreMessage(rpc.Shape):
+    """
+    IoTCoreMessage is a "tagged union" class.
+
+    When sending, only one of the attributes may be set.
+    When receiving, only one of the attributes will be set.
+    All other attributes will be None.
+
+    Keyword Args:
+        message: The MQTT message.
+
+    Attributes:
+        message: The MQTT message.
+    """
+
+    def __init__(self, *,
+                 message: typing.Optional[MQTTMessage] = None):
+        super().__init__()
+        self.message = message  # type: typing.Optional[MQTTMessage]
+
+    def set_message(self, message: MQTTMessage):
+        self.message = message
+        return self
+
+
+    def _to_payload(self):
+        payload = {}
+        if self.message is not None:
+            payload['message'] = self.message._to_payload()
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'message' in payload:
+            new.message = MQTTMessage._from_payload(payload['message'])
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#IoTCoreMessage'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class InvalidArgumentsError(GreengrassCoreIPCError):
+    """
+    InvalidArgumentsError
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        message: 
+
+    Attributes:
+        message: 
+    """
+
+    def __init__(self, *,
+                 message: typing.Optional[str] = None):
+        super().__init__()
+        self.message = message  # type: typing.Optional[str]
+
+    def set_message(self, message: str):
+        self.message = message
+        return self
+
+
+    def _get_error_type_string(self):
+        return 'client'
+
+    def _to_payload(self):
+        payload = {}
+        if self.message is not None:
+            payload['message'] = self.message
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'message' in payload:
+            new.message = payload['message']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#InvalidArgumentsError'
 
     def __repr__(self):
         attrs = []
@@ -2019,6 +2237,74 @@ class InvalidRecipeDirectoryPathError(GreengrassCoreIPCError):
         return False
 
 
+class ServiceError(GreengrassCoreIPCError):
+    """
+    ServiceError
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        message: 
+        context: 
+
+    Attributes:
+        message: 
+        context: 
+    """
+
+    def __init__(self, *,
+                 message: typing.Optional[str] = None,
+                 context: typing.Optional[typing.Dict[str, typing.Any]] = None):
+        super().__init__()
+        self.message = message  # type: typing.Optional[str]
+        self.context = context  # type: typing.Optional[typing.Dict[str, typing.Any]]
+
+    def set_message(self, message: str):
+        self.message = message
+        return self
+
+    def set_context(self, context: typing.Dict[str, typing.Any]):
+        self.context = context
+        return self
+
+
+    def _get_error_type_string(self):
+        return 'server'
+
+    def _to_payload(self):
+        payload = {}
+        if self.message is not None:
+            payload['message'] = self.message
+        if self.context is not None:
+            payload['context'] = self.context
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'message' in payload:
+            new.message = payload['message']
+        if 'context' in payload:
+            new.context = payload['context']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ServiceError'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
 class CreateLocalDeploymentResponse(rpc.Shape):
     """
     CreateLocalDeploymentResponse
@@ -2026,10 +2312,10 @@ class CreateLocalDeploymentResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        deployment_id: 
+        deployment_id: The ID of the local deployment that the request created.
 
     Attributes:
-        deployment_id: 
+        deployment_id: The ID of the local deployment that the request created.
     """
 
     def __init__(self, *,
@@ -2079,22 +2365,22 @@ class CreateLocalDeploymentRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        group_name: 
-        root_component_versions_to_add: 
-        root_components_to_remove: 
-        component_to_configuration: 
-        component_to_run_with_info: 
-        recipe_directory_path: 
-        artifacts_directory_path: 
+        group_name: The thing group name the deployment is targeting. If the group name is not specified, "LOCAL_DEPLOYMENT" will be used.
+        root_component_versions_to_add: Map of component name to version. Components will be added to the group's existing root components.
+        root_components_to_remove: List of components that need to be removed from the group, for example if new artifacts were loaded in this request but recipe version did not change.
+        component_to_configuration: Map of component names to configuration.
+        component_to_run_with_info: Map of component names to component run as info.
+        recipe_directory_path: All recipes files in this directory will be copied over to the Greengrass package store.
+        artifacts_directory_path: All artifact files in this directory will be copied over to the Greengrass package store.
 
     Attributes:
-        group_name: 
-        root_component_versions_to_add: 
-        root_components_to_remove: 
-        component_to_configuration: 
-        component_to_run_with_info: 
-        recipe_directory_path: 
-        artifacts_directory_path: 
+        group_name: The thing group name the deployment is targeting. If the group name is not specified, "LOCAL_DEPLOYMENT" will be used.
+        root_component_versions_to_add: Map of component name to version. Components will be added to the group's existing root components.
+        root_components_to_remove: List of components that need to be removed from the group, for example if new artifacts were loaded in this request but recipe version did not change.
+        component_to_configuration: Map of component names to configuration.
+        component_to_run_with_info: Map of component names to component run as info.
+        recipe_directory_path: All recipes files in this directory will be copied over to the Greengrass package store.
+        artifacts_directory_path: All artifact files in this directory will be copied over to the Greengrass package store.
     """
 
     def __init__(self, *,
@@ -2197,6 +2483,142 @@ class CreateLocalDeploymentRequest(rpc.Shape):
         return False
 
 
+class ResourceNotFoundError(GreengrassCoreIPCError):
+    """
+    ResourceNotFoundError
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        message: 
+        resource_type: 
+        resource_name: 
+
+    Attributes:
+        message: 
+        resource_type: 
+        resource_name: 
+    """
+
+    def __init__(self, *,
+                 message: typing.Optional[str] = None,
+                 resource_type: typing.Optional[str] = None,
+                 resource_name: typing.Optional[str] = None):
+        super().__init__()
+        self.message = message  # type: typing.Optional[str]
+        self.resource_type = resource_type  # type: typing.Optional[str]
+        self.resource_name = resource_name  # type: typing.Optional[str]
+
+    def set_message(self, message: str):
+        self.message = message
+        return self
+
+    def set_resource_type(self, resource_type: str):
+        self.resource_type = resource_type
+        return self
+
+    def set_resource_name(self, resource_name: str):
+        self.resource_name = resource_name
+        return self
+
+
+    def _get_error_type_string(self):
+        return 'client'
+
+    def _to_payload(self):
+        payload = {}
+        if self.message is not None:
+            payload['message'] = self.message
+        if self.resource_type is not None:
+            payload['resourceType'] = self.resource_type
+        if self.resource_name is not None:
+            payload['resourceName'] = self.resource_name
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'message' in payload:
+            new.message = payload['message']
+        if 'resourceType' in payload:
+            new.resource_type = payload['resourceType']
+        if 'resourceName' in payload:
+            new.resource_name = payload['resourceName']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ResourceNotFoundError'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class UnauthorizedError(GreengrassCoreIPCError):
+    """
+    UnauthorizedError
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        message: 
+
+    Attributes:
+        message: 
+    """
+
+    def __init__(self, *,
+                 message: typing.Optional[str] = None):
+        super().__init__()
+        self.message = message  # type: typing.Optional[str]
+
+    def set_message(self, message: str):
+        self.message = message
+        return self
+
+
+    def _get_error_type_string(self):
+        return 'client'
+
+    def _to_payload(self):
+        payload = {}
+        if self.message is not None:
+            payload['message'] = self.message
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'message' in payload:
+            new.message = payload['message']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#UnauthorizedError'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
 class PauseComponentResponse(rpc.Shape):
     """
     PauseComponentResponse
@@ -2239,10 +2661,10 @@ class PauseComponentRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
+        component_name: The name of the component to pause, which must be a generic component.
 
     Attributes:
-        component_name: 
+        component_name: The name of the component to pause, which must be a generic component.
     """
 
     def __init__(self, *,
@@ -2285,6 +2707,62 @@ class PauseComponentRequest(rpc.Shape):
         return False
 
 
+class ComponentNotFoundError(GreengrassCoreIPCError):
+    """
+    ComponentNotFoundError
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        message: 
+
+    Attributes:
+        message: 
+    """
+
+    def __init__(self, *,
+                 message: typing.Optional[str] = None):
+        super().__init__()
+        self.message = message  # type: typing.Optional[str]
+
+    def set_message(self, message: str):
+        self.message = message
+        return self
+
+
+    def _get_error_type_string(self):
+        return 'client'
+
+    def _to_payload(self):
+        payload = {}
+        if self.message is not None:
+            payload['message'] = self.message
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'message' in payload:
+            new.message = payload['message']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ComponentNotFoundError'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
 class StopComponentResponse(rpc.Shape):
     """
     StopComponentResponse
@@ -2292,12 +2770,12 @@ class StopComponentResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        stop_status: RequestStatus enum value
-        message: 
+        stop_status: RequestStatus enum value. The status of the stop request.
+        message: A message about why the component failed to stop, if the request failed.
 
     Attributes:
-        stop_status: RequestStatus enum value
-        message: 
+        stop_status: RequestStatus enum value. The status of the stop request.
+        message: A message about why the component failed to stop, if the request failed.
     """
 
     def __init__(self, *,
@@ -2357,10 +2835,10 @@ class StopComponentRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
+        component_name: The name of the component.
 
     Attributes:
-        component_name: 
+        component_name: The name of the component.
     """
 
     def __init__(self, *,
@@ -2410,10 +2888,10 @@ class ListLocalDeploymentsResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        local_deployments: 
+        local_deployments: The list of local deployments.
 
     Attributes:
-        local_deployments: 
+        local_deployments: The list of local deployments.
     """
 
     def __init__(self, *,
@@ -2568,14 +3046,14 @@ class ListNamedShadowsForThingResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        results: 
-        timestamp: 
-        next_token: 
+        results: The list of shadow names.
+        timestamp: (Optional) The date and time that the response was generated.
+        next_token: (Optional) The token value to use in paged requests to retrieve the next page in the sequence. This token isn't present when there are no more shadow names to return.
 
     Attributes:
-        results: 
-        timestamp: 
-        next_token: 
+        results: The list of shadow names.
+        timestamp: (Optional) The date and time that the response was generated.
+        next_token: (Optional) The token value to use in paged requests to retrieve the next page in the sequence. This token isn't present when there are no more shadow names to return.
     """
 
     def __init__(self, *,
@@ -2645,14 +3123,14 @@ class ListNamedShadowsForThingRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        thing_name: 
-        next_token: 
-        page_size: 
+        thing_name: The name of the thing.
+        next_token: (Optional) The token to retrieve the next set of results. This value is returned on paged results and is used in the call that returns the next page.
+        page_size: (Optional) The number of shadow names to return in each call. Value must be between 1 and 100. Default is 25.
 
     Attributes:
-        thing_name: 
-        next_token: 
-        page_size: 
+        thing_name: The name of the thing.
+        next_token: (Optional) The token to retrieve the next set of results. This value is returned on paged results and is used in the call that returns the next page.
+        page_size: (Optional) The number of shadow names to return in each call. Value must be between 1 and 100. Default is 25.
     """
 
     def __init__(self, *,
@@ -2757,10 +3235,10 @@ class UpdateStateRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        state: ReportedLifecycleState enum value
+        state: ReportedLifecycleState enum value. The state to set this component to.
 
     Attributes:
-        state: ReportedLifecycleState enum value
+        state: ReportedLifecycleState enum value. The state to set this component to.
     """
 
     def __init__(self, *,
@@ -2810,16 +3288,16 @@ class GetSecretValueResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        secret_id: 
-        version_id: 
-        version_stage: 
-        secret_value: 
+        secret_id: The ID of the secret.
+        version_id: The ID of this version of the secret.
+        version_stage: The list of staging labels attached to this version of the secret.
+        secret_value: The value of this version of the secret.
 
     Attributes:
-        secret_id: 
-        version_id: 
-        version_stage: 
-        secret_value: 
+        secret_id: The ID of the secret.
+        version_id: The ID of this version of the secret.
+        version_stage: The list of staging labels attached to this version of the secret.
+        secret_value: The value of this version of the secret.
     """
 
     def __init__(self, *,
@@ -2899,14 +3377,14 @@ class GetSecretValueRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        secret_id: 
-        version_id: 
-        version_stage: 
+        secret_id: The name of the secret to get. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.
+        version_id: (Optional) The ID of the version to get. If you don't specify versionId or versionStage, this operation defaults to the version with the AWSCURRENT label.
+        version_stage: (Optional) The staging label of the version to get. If you don't specify versionId or versionStage, this operation defaults to the version with the AWSCURRENT label.
 
     Attributes:
-        secret_id: 
-        version_id: 
-        version_stage: 
+        secret_id: The name of the secret to get. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.
+        version_id: (Optional) The ID of the version to get. If you don't specify versionId or versionStage, this operation defaults to the version with the AWSCURRENT label.
+        version_stage: (Optional) The staging label of the version to get. If you don't specify versionId or versionStage, this operation defaults to the version with the AWSCURRENT label.
     """
 
     def __init__(self, *,
@@ -2976,10 +3454,10 @@ class GetLocalDeploymentStatusResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        deployment: 
+        deployment: The local deployment.
 
     Attributes:
-        deployment: 
+        deployment: The local deployment.
     """
 
     def __init__(self, *,
@@ -3029,10 +3507,10 @@ class GetLocalDeploymentStatusRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        deployment_id: 
+        deployment_id: The ID of the local deployment to get.
 
     Attributes:
-        deployment_id: 
+        deployment_id: The ID of the local deployment to get.
     """
 
     def __init__(self, *,
@@ -3075,62 +3553,6 @@ class GetLocalDeploymentStatusRequest(rpc.Shape):
         return False
 
 
-class ComponentNotFoundError(GreengrassCoreIPCError):
-    """
-    ComponentNotFoundError
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        message: 
-
-    Attributes:
-        message: 
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[str] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[str]
-
-    def set_message(self, message: str):
-        self.message = message
-        return self
-
-
-    def _get_error_type_string(self):
-        return 'client'
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = payload['message']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#ComponentNotFoundError'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
 class RestartComponentResponse(rpc.Shape):
     """
     RestartComponentResponse
@@ -3138,12 +3560,12 @@ class RestartComponentResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        restart_status: RequestStatus enum value
-        message: 
+        restart_status: RequestStatus enum value. The status of the restart request.
+        message: A message about why the component failed to restart, if the request failed.
 
     Attributes:
-        restart_status: RequestStatus enum value
-        message: 
+        restart_status: RequestStatus enum value. The status of the restart request.
+        message: A message about why the component failed to restart, if the request failed.
     """
 
     def __init__(self, *,
@@ -3203,10 +3625,10 @@ class RestartComponentRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
+        component_name: The name of the component.
 
     Attributes:
-        component_name: 
+        component_name: The name of the component.
     """
 
     def __init__(self, *,
@@ -3467,6 +3889,62 @@ class FailedUpdateConditionCheckError(GreengrassCoreIPCError):
         return False
 
 
+class ConflictError(GreengrassCoreIPCError):
+    """
+    ConflictError
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        message: 
+
+    Attributes:
+        message: 
+    """
+
+    def __init__(self, *,
+                 message: typing.Optional[str] = None):
+        super().__init__()
+        self.message = message  # type: typing.Optional[str]
+
+    def set_message(self, message: str):
+        self.message = message
+        return self
+
+
+    def _get_error_type_string(self):
+        return 'client'
+
+    def _to_payload(self):
+        payload = {}
+        if self.message is not None:
+            payload['message'] = self.message
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'message' in payload:
+            new.message = payload['message']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'aws.greengrass#ConflictError'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
 class UpdateConfigurationResponse(rpc.Shape):
     """
     UpdateConfigurationResponse
@@ -3509,14 +3987,14 @@ class UpdateConfigurationRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        key_path: 
-        timestamp: 
-        value_to_merge: 
+        key_path: (Optional) The key path to the container node (the object) to update. Specify a list where each entry is the key for a single level in the configuration object. Defaults to the root of the configuration object.
+        timestamp: The current Unix epoch time in milliseconds. This operation uses this timestamp to resolve concurrent updates to the key. If the key in the component configuration has a greater timestamp than the timestamp in the request, then the request fails.
+        value_to_merge: The configuration object to merge at the location that you specify in keyPath.
 
     Attributes:
-        key_path: 
-        timestamp: 
-        value_to_merge: 
+        key_path: (Optional) The key path to the container node (the object) to update. Specify a list where each entry is the key for a single level in the configuration object. Defaults to the root of the configuration object.
+        timestamp: The current Unix epoch time in milliseconds. This operation uses this timestamp to resolve concurrent updates to the key. If the key in the component configuration has a greater timestamp than the timestamp in the request, then the request fails.
+        value_to_merge: The configuration object to merge at the location that you specify in keyPath.
     """
 
     def __init__(self, *,
@@ -3579,62 +4057,6 @@ class UpdateConfigurationRequest(rpc.Shape):
         return False
 
 
-class ConflictError(GreengrassCoreIPCError):
-    """
-    ConflictError
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        message: 
-
-    Attributes:
-        message: 
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[str] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[str]
-
-    def set_message(self, message: str):
-        self.message = message
-        return self
-
-
-    def _get_error_type_string(self):
-        return 'client'
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = payload['message']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#ConflictError'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
 class UpdateThingShadowResponse(rpc.Shape):
     """
     UpdateThingShadowResponse
@@ -3642,10 +4064,10 @@ class UpdateThingShadowResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        payload: 
+        payload: The response state document as a JSON encoded blob.
 
     Attributes:
-        payload: 
+        payload: The response state document as a JSON encoded blob.
     """
 
     def __init__(self, *,
@@ -3699,14 +4121,14 @@ class UpdateThingShadowRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        thing_name: 
-        shadow_name: 
-        payload: 
+        thing_name: The name of the thing.
+        shadow_name: The name of the shadow. To specify the thing's classic shadow, set this parameter to an empty string ("").
+        payload: The request state document as a JSON encoded blob.
 
     Attributes:
-        thing_name: 
-        shadow_name: 
-        payload: 
+        thing_name: The name of the thing.
+        shadow_name: The name of the shadow. To specify the thing's classic shadow, set this parameter to an empty string ("").
+        payload: The request state document as a JSON encoded blob.
     """
 
     def __init__(self, *,
@@ -3815,10 +4237,10 @@ class SendConfigurationValidityReportRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        configuration_validity_report: 
+        configuration_validity_report: The report that tells Greengrass whether or not the configuration update is valid.
 
     Attributes:
-        configuration_validity_report: 
+        configuration_validity_report: The report that tells Greengrass whether or not the configuration update is valid.
     """
 
     def __init__(self, *,
@@ -3868,10 +4290,10 @@ class GetThingShadowResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        payload: 
+        payload: The response state document as a JSON encoded blob.
 
     Attributes:
-        payload: 
+        payload: The response state document as a JSON encoded blob.
     """
 
     def __init__(self, *,
@@ -3925,12 +4347,12 @@ class GetThingShadowRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        thing_name: 
-        shadow_name: 
+        thing_name: The name of the thing.
+        shadow_name: The name of the shadow. To specify the thing's classic shadow, set this parameter to an empty string ("").
 
     Attributes:
-        thing_name: 
-        shadow_name: 
+        thing_name: The name of the thing.
+        shadow_name: The name of the shadow. To specify the thing's classic shadow, set this parameter to an empty string ("").
     """
 
     def __init__(self, *,
@@ -4126,10 +4548,10 @@ class ListComponentsResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        components: 
+        components: The list of components.
 
     Attributes:
-        components: 
+        components: The list of components.
     """
 
     def __init__(self, *,
@@ -4270,10 +4692,10 @@ class AuthorizeClientDeviceActionResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        is_authorized: 
+        is_authorized: Whether the client device is authorized to perform the operation on the resource.
 
     Attributes:
-        is_authorized: 
+        is_authorized: Whether the client device is authorized to perform the operation on the resource.
     """
 
     def __init__(self, *,
@@ -4323,14 +4745,14 @@ class AuthorizeClientDeviceActionRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        client_device_auth_token: 
-        operation: 
-        resource: 
+        client_device_auth_token: The session token for the client device from GetClientDeviceAuthToken.
+        operation: The operation to authorize.
+        resource: The resource the client device performs the operation on.
 
     Attributes:
-        client_device_auth_token: 
-        operation: 
-        resource: 
+        client_device_auth_token: The session token for the client device from GetClientDeviceAuthToken.
+        operation: The operation to authorize.
+        resource: The resource the client device performs the operation on.
     """
 
     def __init__(self, *,
@@ -4400,10 +4822,10 @@ class VerifyClientDeviceIdentityResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        is_valid_client_device: 
+        is_valid_client_device: Whether the client device's identity is valid.
 
     Attributes:
-        is_valid_client_device: 
+        is_valid_client_device: Whether the client device's identity is valid.
     """
 
     def __init__(self, *,
@@ -4453,10 +4875,10 @@ class VerifyClientDeviceIdentityRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        credential: 
+        credential: The client device's credentials.
 
     Attributes:
-        credential: 
+        credential: The client device's credentials.
     """
 
     def __init__(self, *,
@@ -4629,12 +5051,12 @@ class PublishToTopicRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        topic: 
-        publish_message: 
+        topic: The topic to publish the message.
+        publish_message: The message to publish.
 
     Attributes:
-        topic: 
-        publish_message: 
+        topic: The topic to publish the message.
+        publish_message: The message to publish.
     """
 
     def __init__(self, *,
@@ -4750,10 +5172,10 @@ class GetClientDeviceAuthTokenResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        client_device_auth_token: 
+        client_device_auth_token: The session token for the client device. You can use this session token in subsequent requests to authorize this client device's actions.
 
     Attributes:
-        client_device_auth_token: 
+        client_device_auth_token: The session token for the client device. You can use this session token in subsequent requests to authorize this client device's actions.
     """
 
     def __init__(self, *,
@@ -4803,10 +5225,10 @@ class GetClientDeviceAuthTokenRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        credential: 
+        credential: The client device's credentials.
 
     Attributes:
-        credential: 
+        credential: The client device's credentials.
     """
 
     def __init__(self, *,
@@ -4856,10 +5278,10 @@ class GetComponentDetailsResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_details: 
+        component_details: The component's details.
 
     Attributes:
-        component_details: 
+        component_details: The component's details.
     """
 
     def __init__(self, *,
@@ -4909,10 +5331,10 @@ class GetComponentDetailsRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
+        component_name: The name of the component to get.
 
     Attributes:
-        component_name: 
+        component_name: The name of the component to get.
     """
 
     def __init__(self, *,
@@ -5015,12 +5437,12 @@ class SubscribeToTopicRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        topic: 
-        receive_mode: ReceiveMode enum value
+        topic: The topic to subscribe to. Supports MQTT-style wildcards.
+        receive_mode: ReceiveMode enum value. (Optional) The behavior that specifies whether the component receives messages from itself.
 
     Attributes:
-        topic: 
-        receive_mode: ReceiveMode enum value
+        topic: The topic to subscribe to. Supports MQTT-style wildcards.
+        receive_mode: ReceiveMode enum value. (Optional) The behavior that specifies whether the component receives messages from itself.
     """
 
     def __init__(self, *,
@@ -5080,12 +5502,12 @@ class GetConfigurationResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
-        value: 
+        component_name: The name of the component.
+        value: The requested configuration as an object.
 
     Attributes:
-        component_name: 
-        value: 
+        component_name: The name of the component.
+        value: The requested configuration as an object.
     """
 
     def __init__(self, *,
@@ -5145,12 +5567,12 @@ class GetConfigurationRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
-        key_path: 
+        component_name: (Optional) The name of the component. Defaults to the name of the component that makes the request.
+        key_path: The key path to the configuration value. Specify a list where each entry is the key for a single level in the configuration object.
 
     Attributes:
-        component_name: 
-        key_path: 
+        component_name: (Optional) The name of the component. Defaults to the name of the component that makes the request.
+        key_path: The key path to the configuration value. Specify a list where each entry is the key for a single level in the configuration object.
     """
 
     def __init__(self, *,
@@ -5315,14 +5737,14 @@ class DeferComponentUpdateRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        deployment_id: 
-        message: 
-        recheck_after_ms: 
+        deployment_id: The ID of the AWS IoT Greengrass deployment to defer.
+        message: (Optional) The name of the component for which to defer updates. Defaults to the name of the component that makes the request.
+        recheck_after_ms: The amount of time in milliseconds for which to defer the update. Greengrass waits for this amount of time and then sends another PreComponentUpdateEvent
 
     Attributes:
-        deployment_id: 
-        message: 
-        recheck_after_ms: 
+        deployment_id: The ID of the AWS IoT Greengrass deployment to defer.
+        message: (Optional) The name of the component for which to defer updates. Defaults to the name of the component that makes the request.
+        recheck_after_ms: The amount of time in milliseconds for which to defer the update. Greengrass waits for this amount of time and then sends another PreComponentUpdateEvent
     """
 
     def __init__(self, *,
@@ -5473,62 +5895,6 @@ class PutComponentMetricRequest(rpc.Shape):
         return False
 
 
-class InvalidArgumentsError(GreengrassCoreIPCError):
-    """
-    InvalidArgumentsError
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        message: 
-
-    Attributes:
-        message: 
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[str] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[str]
-
-    def set_message(self, message: str):
-        self.message = message
-        return self
-
-
-    def _get_error_type_string(self):
-        return 'client'
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = payload['message']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#InvalidArgumentsError'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
 class DeleteThingShadowResponse(rpc.Shape):
     """
     DeleteThingShadowResponse
@@ -5536,10 +5902,10 @@ class DeleteThingShadowResponse(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        payload: 
+        payload: An empty response state document.
 
     Attributes:
-        payload: 
+        payload: An empty response state document.
     """
 
     def __init__(self, *,
@@ -5593,12 +5959,12 @@ class DeleteThingShadowRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        thing_name: 
-        shadow_name: 
+        thing_name: The name of the thing.
+        shadow_name: The name of the shadow. To specify the thing's classic shadow, set this parameter to an empty string ("").
 
     Attributes:
-        thing_name: 
-        shadow_name: 
+        thing_name: The name of the thing.
+        shadow_name: The name of the shadow. To specify the thing's classic shadow, set this parameter to an empty string ("").
     """
 
     def __init__(self, *,
@@ -5693,12 +6059,12 @@ class SubscribeToConfigurationUpdateRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
-        key_path: 
+        component_name: (Optional) The name of the component. Defaults to the name of the component that makes the request.
+        key_path: The key path to the configuration value for which to subscribe. Specify a list where each entry is the key for a single level in the configuration object.
 
     Attributes:
-        component_name: 
-        key_path: 
+        component_name: (Optional) The name of the component. Defaults to the name of the component that makes the request.
+        key_path: The key path to the configuration value for which to subscribe. Specify a list where each entry is the key for a single level in the configuration object.
     """
 
     def __init__(self, *,
@@ -5793,26 +6159,56 @@ class PublishToIoTCoreRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        topic_name: 
-        qos: QOS enum value
-        payload: 
+        topic_name: The topic to which to publish the message.
+        qos: QOS enum value. The MQTT QoS to use.
+        payload: (Optional) The message payload as a blob.
+        retain: (Optional) Whether to set MQTT retain option to true when publishing.
+        user_properties: (Optional) MQTT user properties associated with the message.
+        message_expiry_interval_seconds: (Optional) Message expiry interval in seconds.
+        correlation_data: (Optional) Correlation data blob for request/response.
+        response_topic: (Optional) Response topic for request/response.
+        payload_format: PayloadFormat enum value. (Optional) Message payload format.
+        content_type: (Optional) Message content type.
 
     Attributes:
-        topic_name: 
-        qos: QOS enum value
-        payload: 
+        topic_name: The topic to which to publish the message.
+        qos: QOS enum value. The MQTT QoS to use.
+        payload: (Optional) The message payload as a blob.
+        retain: (Optional) Whether to set MQTT retain option to true when publishing.
+        user_properties: (Optional) MQTT user properties associated with the message.
+        message_expiry_interval_seconds: (Optional) Message expiry interval in seconds.
+        correlation_data: (Optional) Correlation data blob for request/response.
+        response_topic: (Optional) Response topic for request/response.
+        payload_format: PayloadFormat enum value. (Optional) Message payload format.
+        content_type: (Optional) Message content type.
     """
 
     def __init__(self, *,
                  topic_name: typing.Optional[str] = None,
                  qos: typing.Optional[str] = None,
-                 payload: typing.Optional[typing.Union[bytes, str]] = None):
+                 payload: typing.Optional[typing.Union[bytes, str]] = None,
+                 retain: typing.Optional[bool] = None,
+                 user_properties: typing.Optional[typing.List[UserProperty]] = None,
+                 message_expiry_interval_seconds: typing.Optional[int] = None,
+                 correlation_data: typing.Optional[typing.Union[bytes, str]] = None,
+                 response_topic: typing.Optional[str] = None,
+                 payload_format: typing.Optional[str] = None,
+                 content_type: typing.Optional[str] = None):
         super().__init__()
         self.topic_name = topic_name  # type: typing.Optional[str]
         self.qos = qos  # type: typing.Optional[str]
         if payload is not None and isinstance(payload, str):
             payload = payload.encode('utf-8')
         self.payload = payload  # type: typing.Optional[bytes]
+        self.retain = retain  # type: typing.Optional[bool]
+        self.user_properties = user_properties  # type: typing.Optional[typing.List[UserProperty]]
+        self.message_expiry_interval_seconds = message_expiry_interval_seconds  # type: typing.Optional[int]
+        if correlation_data is not None and isinstance(correlation_data, str):
+            correlation_data = correlation_data.encode('utf-8')
+        self.correlation_data = correlation_data  # type: typing.Optional[bytes]
+        self.response_topic = response_topic  # type: typing.Optional[str]
+        self.payload_format = payload_format  # type: typing.Optional[str]
+        self.content_type = content_type  # type: typing.Optional[str]
 
     def set_topic_name(self, topic_name: str):
         self.topic_name = topic_name
@@ -5828,6 +6224,36 @@ class PublishToIoTCoreRequest(rpc.Shape):
         self.payload = payload
         return self
 
+    def set_retain(self, retain: bool):
+        self.retain = retain
+        return self
+
+    def set_user_properties(self, user_properties: typing.List[UserProperty]):
+        self.user_properties = user_properties
+        return self
+
+    def set_message_expiry_interval_seconds(self, message_expiry_interval_seconds: int):
+        self.message_expiry_interval_seconds = message_expiry_interval_seconds
+        return self
+
+    def set_correlation_data(self, correlation_data: typing.Union[bytes, str]):
+        if correlation_data is not None and isinstance(correlation_data, str):
+            correlation_data = correlation_data.encode('utf-8')
+        self.correlation_data = correlation_data
+        return self
+
+    def set_response_topic(self, response_topic: str):
+        self.response_topic = response_topic
+        return self
+
+    def set_payload_format(self, payload_format: str):
+        self.payload_format = payload_format
+        return self
+
+    def set_content_type(self, content_type: str):
+        self.content_type = content_type
+        return self
+
 
     def _to_payload(self):
         payload = {}
@@ -5837,6 +6263,20 @@ class PublishToIoTCoreRequest(rpc.Shape):
             payload['qos'] = self.qos
         if self.payload is not None:
             payload['payload'] = base64.b64encode(self.payload).decode()
+        if self.retain is not None:
+            payload['retain'] = self.retain
+        if self.user_properties is not None:
+            payload['userProperties'] = [i._to_payload() for i in self.user_properties]
+        if self.message_expiry_interval_seconds is not None:
+            payload['messageExpiryIntervalSeconds'] = self.message_expiry_interval_seconds
+        if self.correlation_data is not None:
+            payload['correlationData'] = base64.b64encode(self.correlation_data).decode()
+        if self.response_topic is not None:
+            payload['responseTopic'] = self.response_topic
+        if self.payload_format is not None:
+            payload['payloadFormat'] = self.payload_format
+        if self.content_type is not None:
+            payload['contentType'] = self.content_type
         return payload
 
     @classmethod
@@ -5848,91 +6288,25 @@ class PublishToIoTCoreRequest(rpc.Shape):
             new.qos = payload['qos']
         if 'payload' in payload:
             new.payload = base64.b64decode(payload['payload'])
+        if 'retain' in payload:
+            new.retain = payload['retain']
+        if 'userProperties' in payload:
+            new.user_properties = [UserProperty._from_payload(i) for i in payload['userProperties']]
+        if 'messageExpiryIntervalSeconds' in payload:
+            new.message_expiry_interval_seconds = int(payload['messageExpiryIntervalSeconds'])
+        if 'correlationData' in payload:
+            new.correlation_data = base64.b64decode(payload['correlationData'])
+        if 'responseTopic' in payload:
+            new.response_topic = payload['responseTopic']
+        if 'payloadFormat' in payload:
+            new.payload_format = payload['payloadFormat']
+        if 'contentType' in payload:
+            new.content_type = payload['contentType']
         return new
 
     @classmethod
     def _model_name(cls):
         return 'aws.greengrass#PublishToIoTCoreRequest'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class ResourceNotFoundError(GreengrassCoreIPCError):
-    """
-    ResourceNotFoundError
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        message: 
-        resource_type: 
-        resource_name: 
-
-    Attributes:
-        message: 
-        resource_type: 
-        resource_name: 
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[str] = None,
-                 resource_type: typing.Optional[str] = None,
-                 resource_name: typing.Optional[str] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[str]
-        self.resource_type = resource_type  # type: typing.Optional[str]
-        self.resource_name = resource_name  # type: typing.Optional[str]
-
-    def set_message(self, message: str):
-        self.message = message
-        return self
-
-    def set_resource_type(self, resource_type: str):
-        self.resource_type = resource_type
-        return self
-
-    def set_resource_name(self, resource_name: str):
-        self.resource_name = resource_name
-        return self
-
-
-    def _get_error_type_string(self):
-        return 'client'
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message
-        if self.resource_type is not None:
-            payload['resourceType'] = self.resource_type
-        if self.resource_name is not None:
-            payload['resourceName'] = self.resource_name
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = payload['message']
-        if 'resourceType' in payload:
-            new.resource_type = payload['resourceType']
-        if 'resourceName' in payload:
-            new.resource_name = payload['resourceName']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#ResourceNotFoundError'
 
     def __repr__(self):
         attrs = []
@@ -5989,10 +6363,10 @@ class ResumeComponentRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        component_name: 
+        component_name: The name of the component to resume.
 
     Attributes:
-        component_name: 
+        component_name: The name of the component to resume.
     """
 
     def __init__(self, *,
@@ -6021,118 +6395,6 @@ class ResumeComponentRequest(rpc.Shape):
     @classmethod
     def _model_name(cls):
         return 'aws.greengrass#ResumeComponentRequest'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class UnauthorizedError(GreengrassCoreIPCError):
-    """
-    UnauthorizedError
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        message: 
-
-    Attributes:
-        message: 
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[str] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[str]
-
-    def set_message(self, message: str):
-        self.message = message
-        return self
-
-
-    def _get_error_type_string(self):
-        return 'client'
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = payload['message']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#UnauthorizedError'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
-class ServiceError(GreengrassCoreIPCError):
-    """
-    ServiceError
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        message: 
-
-    Attributes:
-        message: 
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[str] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[str]
-
-    def set_message(self, message: str):
-        self.message = message
-        return self
-
-
-    def _get_error_type_string(self):
-        return 'server'
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = payload['message']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'aws.greengrass#ServiceError'
 
     def __repr__(self):
         attrs = []
@@ -6189,12 +6451,12 @@ class SubscribeToIoTCoreRequest(rpc.Shape):
     All attributes are None by default, and may be set by keyword in the constructor.
 
     Keyword Args:
-        topic_name: 
-        qos: QOS enum value
+        topic_name: The topic to which to subscribe. Supports MQTT wildcards.
+        qos: QOS enum value. The MQTT QoS to use.
 
     Attributes:
-        topic_name: 
-        qos: QOS enum value
+        topic_name: The topic to which to subscribe. Supports MQTT wildcards.
+        qos: QOS enum value. The MQTT QoS to use.
     """
 
     def __init__(self, *,
@@ -6248,29 +6510,35 @@ class SubscribeToIoTCoreRequest(rpc.Shape):
 
 
 SHAPE_INDEX = rpc.ShapeIndex([
+    UserProperty,
     SystemResourceLimits,
     MessageContext,
-    ValidateConfigurationUpdateEvent,
     RunWithInfo,
-    PreComponentUpdateEvent,
+    LocalDeployment,
     PostComponentUpdateEvent,
-    MQTTMessage,
-    MQTTCredential,
-    Metric,
-    JsonMessage,
-    ConfigurationUpdateEvent,
+    PreComponentUpdateEvent,
+    ComponentDetails,
     CertificateUpdate,
     BinaryMessage,
-    LocalDeployment,
+    JsonMessage,
+    MQTTCredential,
+    ValidateConfigurationUpdateEvent,
+    Metric,
+    ConfigurationUpdateEvent,
+    MQTTMessage,
     ConfigurationValidityReport,
-    ComponentDetails,
     CertificateOptions,
+    InvalidArgumentsError,
     InvalidArtifactsDirectoryPathError,
     InvalidRecipeDirectoryPathError,
+    ServiceError,
     CreateLocalDeploymentResponse,
     CreateLocalDeploymentRequest,
+    ResourceNotFoundError,
+    UnauthorizedError,
     PauseComponentResponse,
     PauseComponentRequest,
+    ComponentNotFoundError,
     StopComponentResponse,
     StopComponentRequest,
     ListLocalDeploymentsResponse,
@@ -6285,16 +6553,15 @@ SHAPE_INDEX = rpc.ShapeIndex([
     GetSecretValueRequest,
     GetLocalDeploymentStatusResponse,
     GetLocalDeploymentStatusRequest,
-    ComponentNotFoundError,
     RestartComponentResponse,
     RestartComponentRequest,
     InvalidTokenError,
     ValidateAuthorizationTokenResponse,
     ValidateAuthorizationTokenRequest,
     FailedUpdateConditionCheckError,
+    ConflictError,
     UpdateConfigurationResponse,
     UpdateConfigurationRequest,
-    ConflictError,
     UpdateThingShadowResponse,
     UpdateThingShadowRequest,
     SendConfigurationValidityReportResponse,
@@ -6329,18 +6596,14 @@ SHAPE_INDEX = rpc.ShapeIndex([
     DeferComponentUpdateRequest,
     PutComponentMetricResponse,
     PutComponentMetricRequest,
-    InvalidArgumentsError,
     DeleteThingShadowResponse,
     DeleteThingShadowRequest,
     SubscribeToConfigurationUpdateResponse,
     SubscribeToConfigurationUpdateRequest,
     PublishToIoTCoreResponse,
     PublishToIoTCoreRequest,
-    ResourceNotFoundError,
     ResumeComponentResponse,
     ResumeComponentRequest,
-    UnauthorizedError,
-    ServiceError,
     SubscribeToIoTCoreResponse,
     SubscribeToIoTCoreRequest,
 ])

--- a/test/echotestrpc/model.py
+++ b/test/echotestrpc/model.py
@@ -257,7 +257,7 @@ class MessageData(rpc.Shape):
         boolean_message: 
         time_message: 
         document_message: 
-        enum_message: FruitEnum enum value
+        enum_message: FruitEnum enum value. 
         blob_message: 
         string_list_message: 
         key_value_pair_list: 
@@ -268,7 +268,7 @@ class MessageData(rpc.Shape):
         boolean_message: 
         time_message: 
         document_message: 
-        enum_message: FruitEnum enum value
+        enum_message: FruitEnum enum value. 
         blob_message: 
         string_list_message: 
         key_value_pair_list: 
@@ -452,6 +452,74 @@ class EchoStreamingMessage(rpc.Shape):
     @classmethod
     def _model_name(cls):
         return 'awstest#EchoStreamingMessage'
+
+    def __repr__(self):
+        attrs = []
+        for attr, val in self.__dict__.items():
+            if val is not None:
+                attrs.append('%s=%r' % (attr, val))
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+
+class ServiceError(EchoTestRPCError):
+    """
+    ServiceError
+
+    All attributes are None by default, and may be set by keyword in the constructor.
+
+    Keyword Args:
+        message: 
+        value: 
+
+    Attributes:
+        message: 
+        value: 
+    """
+
+    def __init__(self, *,
+                 message: typing.Optional[str] = None,
+                 value: typing.Optional[str] = None):
+        super().__init__()
+        self.message = message  # type: typing.Optional[str]
+        self.value = value  # type: typing.Optional[str]
+
+    def set_message(self, message: str):
+        self.message = message
+        return self
+
+    def set_value(self, value: str):
+        self.value = value
+        return self
+
+
+    def _get_error_type_string(self):
+        return 'server'
+
+    def _to_payload(self):
+        payload = {}
+        if self.message is not None:
+            payload['message'] = self.message
+        if self.value is not None:
+            payload['value'] = self.value
+        return payload
+
+    @classmethod
+    def _from_payload(cls, payload):
+        new = cls()
+        if 'message' in payload:
+            new.message = payload['message']
+        if 'value' in payload:
+            new.value = payload['value']
+        return new
+
+    @classmethod
+    def _model_name(cls):
+        return 'awstest#ServiceError'
 
     def __repr__(self):
         attrs = []
@@ -800,74 +868,6 @@ class CauseServiceErrorRequest(rpc.Shape):
         return False
 
 
-class ServiceError(EchoTestRPCError):
-    """
-    ServiceError
-
-    All attributes are None by default, and may be set by keyword in the constructor.
-
-    Keyword Args:
-        message: 
-        value: 
-
-    Attributes:
-        message: 
-        value: 
-    """
-
-    def __init__(self, *,
-                 message: typing.Optional[str] = None,
-                 value: typing.Optional[str] = None):
-        super().__init__()
-        self.message = message  # type: typing.Optional[str]
-        self.value = value  # type: typing.Optional[str]
-
-    def set_message(self, message: str):
-        self.message = message
-        return self
-
-    def set_value(self, value: str):
-        self.value = value
-        return self
-
-
-    def _get_error_type_string(self):
-        return 'server'
-
-    def _to_payload(self):
-        payload = {}
-        if self.message is not None:
-            payload['message'] = self.message
-        if self.value is not None:
-            payload['value'] = self.value
-        return payload
-
-    @classmethod
-    def _from_payload(cls, payload):
-        new = cls()
-        if 'message' in payload:
-            new.message = payload['message']
-        if 'value' in payload:
-            new.value = payload['value']
-        return new
-
-    @classmethod
-    def _model_name(cls):
-        return 'awstest#ServiceError'
-
-    def __repr__(self):
-        attrs = []
-        for attr, val in self.__dict__.items():
-            if val is not None:
-                attrs.append('%s=%r' % (attr, val))
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(attrs))
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.__dict__ == other.__dict__
-        return False
-
-
 class GetAllProductsResponse(rpc.Shape):
     """
     GetAllProductsResponse
@@ -961,6 +961,7 @@ SHAPE_INDEX = rpc.ShapeIndex([
     Pair,
     Customer,
     MessageData,
+    ServiceError,
     GetAllCustomersResponse,
     GetAllCustomersRequest,
     EchoMessageResponse,
@@ -969,7 +970,6 @@ SHAPE_INDEX = rpc.ShapeIndex([
     EchoStreamingRequest,
     CauseServiceErrorResponse,
     CauseServiceErrorRequest,
-    ServiceError,
     GetAllProductsResponse,
     GetAllProductsRequest,
 ])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds new fields to the IPC operations for sending and receiving MQTT messages with IoT Core in order to support MQTT 5 functionality.
Documentation on the models is also now present in the generated code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
