### PR TITLE
Greengrass discovery fix two

### DIFF
--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -66,7 +66,7 @@ def try_iot_endpoints():
                         ca_bytes=gg_group.certificate_authorities[0].encode('utf-8'),
                         on_connection_interrupted=on_connection_interupted,
                         on_connection_resumed=on_connection_resumed,
-                        client_id=cmdData.input_clientId,
+                        client_id=cmdData.input_thing_name,
                         clean_session=False,
                         keep_alive_secs=30)
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -346,6 +346,9 @@ class CommandLineUtils:
         cmdUtils.register_command(
             CommandLineUtils.m_cmd_print_discovery_resp_only, "", "(optional, default='False').",
             default=False, type=bool, action="store_true")
+        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
+                                "Client ID to use for MQTT connection (optional, default='test-*').",
+                                default="test-" + str(uuid4()))
         cmdUtils.add_common_proxy_commands()
         cmdUtils.get_args()
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -362,6 +362,7 @@ class CommandLineUtils:
         cmdData.input_print_discovery_resp_only = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_print_discovery_resp_only, False))
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
+        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 

--- a/samples/utils/command_line_utils.py
+++ b/samples/utils/command_line_utils.py
@@ -346,9 +346,6 @@ class CommandLineUtils:
         cmdUtils.register_command(
             CommandLineUtils.m_cmd_print_discovery_resp_only, "", "(optional, default='False').",
             default=False, type=bool, action="store_true")
-        cmdUtils.register_command(CommandLineUtils.m_cmd_client_id, "<str>",
-                                "Client ID to use for MQTT connection (optional, default='test-*').",
-                                default="test-" + str(uuid4()))
         cmdUtils.add_common_proxy_commands()
         cmdUtils.get_args()
 
@@ -365,7 +362,6 @@ class CommandLineUtils:
         cmdData.input_print_discovery_resp_only = bool(cmdUtils.get_command(CommandLineUtils.m_cmd_print_discovery_resp_only, False))
         cmdData.input_proxy_host = cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_host)
         cmdData.input_proxy_port = int(cmdUtils.get_command(CommandLineUtils.m_cmd_proxy_port))
-        cmdData.input_clientId = cmdUtils.get_command(CommandLineUtils.m_cmd_client_id, "test-" + str(uuid4()))
         cmdData.input_is_ci = cmdUtils.get_command(CommandLineUtils.m_cmd_is_ci, None) != None
         return cmdData
 


### PR DESCRIPTION
*Description of changes:*

Fixes that `cliendId` was not being passed nor read from the command line. ~~Now it is properly registered and assigned as expected.~~ Now it uses the thing name as the cliend ID.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
