### PR TITLE
Run greengrass discovery in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ env:
   CI_SHADOW_ROLE: arn:aws:iam::180635532705:role/CI_Shadow_Role
   CI_JOBS_ROLE: arn:aws:iam::180635532705:role/CI_Jobs_Role
   CI_FLEET_PROVISIONING_ROLE: arn:aws:iam::180635532705:role/service-role/CI_FleetProvisioning_Role
+  CI_GREENGRASS_ROLE: arn:aws:iam::180635532705:role/CI_Greengrass_Role
   CI_DEVICE_ADVISOR: arn:aws:iam::180635532705:role/CI_DeviceAdvisor_Role
   CI_MQTT5_ROLE: arn:aws:iam::180635532705:role/CI_MQTT5_Role
   CI_BUILD_AND_TEST_ROLE: arn:aws:iam::180635532705:role/V2_SDK_Unit_Testing
@@ -297,6 +298,14 @@ jobs:
           Sample_UUID=$(python3  -c "import uuid; print (uuid.uuid4())")
           python3 ${{ env.CI_UTILS_FOLDER }}/run_sample_ci.py --file ${{ env.CI_SAMPLES_CFG_FOLDER }}/ci_run_fleet_provisioning_cfg.json --input_uuid ${Sample_UUID}
           python3 ${{ env.CI_UTILS_FOLDER }}/delete_iot_thing_ci.py --thing_name "Fleet_Thing_${Sample_UUID}" --region "us-east-1"
+      - name: configure AWS credentials (Greengrass)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ env.CI_GREENGRASS_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: run Greengrass Discovery sample
+        run: |
+          python3 ${{ env.CI_UTILS_FOLDER }}/run_sample_ci.py --file ${{ env.CI_SAMPLES_CFG_FOLDER }}/ci_run_greengrass_discovery.json
 
   # check that docs can still build
   check-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: run Greengrass Discovery sample
         run: |
-          python3 ${{ env.CI_UTILS_FOLDER }}/run_sample_ci.py --file ${{ env.CI_SAMPLES_CFG_FOLDER }}/ci_run_greengrass_discovery.json
+          python3 ${{ env.CI_UTILS_FOLDER }}/run_sample_ci.py --file ${{ env.CI_SAMPLES_CFG_FOLDER }}/ci_run_greengrass_discovery_cfg.json
 
   # check that docs can still build
   check-docs:

--- a/.github/workflows/ci_run_greengrass_discovery_cfg.json
+++ b/.github/workflows/ci_run_greengrass_discovery_cfg.json
@@ -5,10 +5,6 @@
     "sample_main_class": "",
     "arguments": [
         {
-            "name": "--endpoint",
-            "secret": "ci/endpoint"
-        },
-        {
             "name": "--cert",
             "secret": "ci/Greengrass/cert",
             "filename": "tmp_certificate.pem"
@@ -33,7 +29,7 @@
         },
         {
             "name": "--print_discovery_resp_only",
-            "data": "true"
+            "data": ""
         }
     ]
 }

--- a/.github/workflows/ci_run_greengrass_discovery_cfg.json
+++ b/.github/workflows/ci_run_greengrass_discovery_cfg.json
@@ -17,7 +17,7 @@
         {
             "name": "--ca_file",
             "secret": "ci/Greengrass/ca",
-            "filename": "tmp_key.pem"
+            "filename": "tmp_ca.pem"
         },
         {
             "name": "--region",

--- a/.github/workflows/ci_run_greengrass_discovery_cfg.json
+++ b/.github/workflows/ci_run_greengrass_discovery_cfg.json
@@ -28,7 +28,7 @@
             "data": "CI_GreenGrass_Thing"
         },
         {
-            "name": "--print_discovery_resp_only",
+            "name": "--print_discover_resp_only",
             "data": ""
         }
     ]

--- a/.github/workflows/ci_run_greengrass_discovery_cfg.json
+++ b/.github/workflows/ci_run_greengrass_discovery_cfg.json
@@ -25,7 +25,7 @@
         },
         {
             "name": "--thing_name",
-            "data": "CI_GreenGrass_Thing"
+            "data": "CI_GreenGrass_Thing_Test"
         },
         {
             "name": "--print_discover_resp_only",

--- a/.github/workflows/ci_run_greengrass_discovery_cfg.json
+++ b/.github/workflows/ci_run_greengrass_discovery_cfg.json
@@ -25,7 +25,11 @@
         },
         {
             "name": "--thing_name",
-            "data": "CI_GreenGrass_Thing_Test"
+            "data": "CI_GreenGrass_Thing"
+        },
+        {
+            "name": "--is_ci",
+            "data": "true"
         },
         {
             "name": "--print_discover_resp_only",

--- a/.github/workflows/ci_run_greengrass_discovery_cfg.json
+++ b/.github/workflows/ci_run_greengrass_discovery_cfg.json
@@ -1,0 +1,39 @@
+{
+    "language": "Python",
+    "sample_file": "./aws-iot-device-sdk-python-v2/samples/basic_discovery.py",
+    "sample_region": "us-east-1",
+    "sample_main_class": "",
+    "arguments": [
+        {
+            "name": "--endpoint",
+            "secret": "ci/endpoint"
+        },
+        {
+            "name": "--cert",
+            "secret": "ci/Greengrass/cert",
+            "filename": "tmp_certificate.pem"
+        },
+        {
+            "name": "--key",
+            "secret": "ci/Greengrass/key",
+            "filename": "tmp_key.pem"
+        },
+        {
+            "name": "--ca_file",
+            "secret": "ci/Greengrass/ca",
+            "filename": "tmp_key.pem"
+        },
+        {
+            "name": "--region",
+            "data": "us-east-1"
+        },
+        {
+            "name": "--thing_name",
+            "data": "CI_GreenGrass_Thing"
+        },
+        {
+            "name": "--print_discovery_resp_only",
+            "data": "true"
+        }
+    ]
+}

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -38,7 +38,7 @@ resp_future = discovery_client.discover(cmdData.input_thing_name)
 discover_response = resp_future.result()
 
 if (cmdData.input_is_ci):
-    print("Received a greengrass discovery result! Not showing result in CI currently.")
+    print("Received a greengrass discovery result! Not showing result in CI for possible data sensitivity.")
 else:
     print(discover_response)
 

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -37,7 +37,11 @@ discovery_client = DiscoveryClient(
 resp_future = discovery_client.discover(cmdData.input_thing_name)
 discover_response = resp_future.result()
 
-print(discover_response)
+if (cmdData.input_is_ci):
+    print("Received a greengrass discovery result! Not showing result in CI currently.")
+else:
+    print(discover_response)
+
 if (cmdData.input_print_discovery_resp_only):
     exit(0)
 

--- a/utils/run_sample_ci.py
+++ b/utils/run_sample_ci.py
@@ -83,7 +83,8 @@ def setup_json_arguments_list(parsed_commands):
                 if isinstance(tmp_value, str) and 'input_uuid' in parsed_commands:
                     if ("$INPUT_UUID" in tmp_value):
                         tmp_value = tmp_value.replace("$INPUT_UUID", parsed_commands.input_uuid)
-                config_json_arguments_list.append(tmp_value)
+                if (tmp_value != None and tmp_value != ""):
+                    config_json_arguments_list.append(tmp_value)
 
             # None of the above? Just print an error
             else:


### PR DESCRIPTION
*Description of changes:*

Adds running the Greengrass discovery sample in CI, set to only print the discovery information, like how it used to be tested. This helps ensure the sample always runs as expected and increases testing coverage.

Also slightly modifies the sample to not show the discovery results when running in CI, just to hide a bit of information that we might not want to show.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
