### PR TITLE
[Demo] Mqtt5 Shadow Service Client Sample 

### DIFF
--- a/awsiot/__init__.py
+++ b/awsiot/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     'mqtt5_client_builder',
 ]
 
-from awscrt import mqtt
+from awscrt import mqtt, mqtt5
 from concurrent.futures import Future
 import json
 from typing import Any, Callable, Dict, Optional, Tuple, TypeVar
@@ -32,8 +32,13 @@ class MqttServiceClient:
         mqtt_connection: MQTT connection to use
     """
 
-    def __init__(self, mqtt_connection: mqtt.Connection):
-        self._mqtt_connection = mqtt_connection  # type: mqtt.Connection
+    def __init__(self, mqtt_connection: mqtt.Connection | mqtt5.Client):
+        if isinstance(mqtt_connection, mqtt.Connection):
+            self._mqtt_connection = mqtt_connection  # type: mqtt.Connection
+        elif isinstance(mqtt_connection, mqtt5.Client):
+            self._mqtt_connection = mqtt_connection.new_connection()
+        else:
+            assert("The service client could only take mqtt.Connection and mqtt5.Client as argument")
 
     @property
     def mqtt_connection(self) -> mqtt.Connection:

--- a/awsiot/__init__.py
+++ b/awsiot/__init__.py
@@ -32,7 +32,7 @@ class MqttServiceClient:
         mqtt_connection: MQTT connection to use
     """
 
-    def __init__(self, mqtt_connection: mqtt.Connection | mqtt5.Client):
+    def __init__(self, mqtt_connection: mqtt.Connection or mqtt5.Client):
         if isinstance(mqtt_connection, mqtt.Connection):
             self._mqtt_connection = mqtt_connection  # type: mqtt.Connection
         elif isinstance(mqtt_connection, mqtt5.Client):

--- a/samples/fleetprovisioning.md
+++ b/samples/fleetprovisioning.md
@@ -1,4 +1,4 @@
-# Fleet provisioning
+# Fleet provisioning MQTT5
 
 [**Return to main sample list**](./README.md)
 
@@ -75,17 +75,77 @@ There are many different ways to run the Fleet Provisioning sample because of ho
 
 ``` sh
 # For Windows: replace 'python3' with 'python' and '/' with '\'
-python3 fleetprovisioning.py --endpoint <endpoint> --cert <file> --key <file> --template_name <name> --template_parameters <parameters>
+python3 fleetprovisioning_mqtt5.py --endpoint <endpoint> --cert <file> --key <file> --template_name <name> --template_parameters <parameters>
 ```
 
 You can also pass a Certificate Authority file (CA) if your certificate and key combination requires it:
 
 ``` sh
 # For Windows: replace 'python3' with 'python' and '/' with '\'
-python3 fleetprovisioning.py --endpoint <endpoint> --cert <file> --key <file> --template_name <name> --template_parameters <parameters> --ca_file <file>
+python3 fleetprovisioning_mqtt5.py --endpoint <endpoint> --cert <file> --key <file> --template_name <name> --template_parameters <parameters> --ca_file <file>
 ```
 
 However, this is just one way using the `CreateKeysAndCertificate` workflow. Below are a detailed list of instructions with the different ways to connect. While the detailed instructions do not show it, you can pass `--ca_file` as needed no matter which way you connect via Fleet Provisioning.
+
+## Service Client Notes
+### Difference relative to MQTT311 IoTIdentityClient
+The IoTIdentityClient with mqtt5 client is almost identical to the mqtt3 one. The only difference is that you would need setup up a Mqtt5 Client and pass it to the IotIdentityClient.
+For how to setup a Mqtt5 Client, please refer to [MQTT5 UserGuide](../documents/MQTT5_Userguide.md) and [MQTT5 PubSub Sample](./mqtt5_pubsub.py)
+
+<table>
+<tr>
+<th>Create a IoTIdentityClient with Mqtt5</th>
+<th>Create a IoTIdentityClient with Mqtt311</th>
+</tr>
+<tr>
+<td>
+
+```python
+  # Create a Mqtt5 Client
+  mqtt5_client = mqtt5_client_builder.mtls_from_path(
+          endpoint,
+          port,
+          cert_filepath,
+          pri_key_filepath,
+          ca_filepath,
+          client_id,
+          clean_session,
+          keep_alive_secs,
+          http_proxy_options,
+          on_lifecycle_connection_success,
+          on_lifecycle_stopped)
+
+  # Create the Identity Client from Mqtt5 Client
+  identity_client = iotidentity.IotIdentityClient(mqtt5_client)
+```
+
+</td>
+<td>
+
+```python
+    # Create a Mqtt311 Connection from the command line data
+    mqtt_connection = mqtt_connection_builder.mtls_from_path(
+        endpoint,
+        port,
+        cert_filepath,
+        pri_key_filepath,
+        ca_filepath,
+        client_id,
+        clean_session,
+        keep_alive_secs,
+        http_proxy_options)
+
+    # Create the Identity Client from Mqtt311 Connection
+    identity_client = iotidentity.IotIdentityClient(mqtt_connection)
+```
+
+</td>
+</tr>
+</table>
+
+### Mqtt5.QoS v.s. Mqtt3.QoS
+As the service client interface is unchanged for both Mqtt3 Connection and Mqtt5 Client,the IotIdentityClient will use Mqtt3.QoS instead of Mqtt5.QoS even with a Mqtt5 Client. You could use mqtt3.QoS.to_mqtt5() and mqtt5.QoS.to_mqtt3() to convert the value.
+
 
 ### Fleet Provisioning Detailed Instructions
 

--- a/samples/jobs.md
+++ b/samples/jobs.md
@@ -1,4 +1,4 @@
-# Jobs
+# Jobs MQTT5
 
 [**Return to main sample list**](./README.md)
 
@@ -73,12 +73,72 @@ Use the following command to run the Jobs sample from the `samples` folder:
 
 ``` sh
 # For Windows: replace 'python3' with 'python' and '/' with '\'
-python3 jobs.py --endpoint <endpoint> --cert <file> --key <file> --thing_name <name>
+python3 jobs_mqtt5.py --endpoint <endpoint> --cert <file> --key <file> --thing_name <name>
 ```
 
 You can also pass a Certificate Authority file (CA) if your certificate and key combination requires it:
 
 ``` sh
 # For Windows: replace 'python3' with 'python' and '/' with '\'
-python3 jobs.py --endpoint <endpoint> --cert <file> --key <file> --thing_name <name> --ca_file <file>
+python3 jobs_mqtt5.py --endpoint <endpoint> --cert <file> --key <file> --thing_name <name> --ca_file <file>
 ```
+
+
+## Service Client Notes
+### Difference relative to MQTT311 IotJobsClient
+The IotJobsClient with mqtt5 client is almost identical to the mqtt3 one. The only difference is that you would need setup up a Mqtt5 Client and pass it to the IotJobsClient.
+For how to setup a Mqtt5 Client, please refer to [MQTT5 UserGuide](../documents/MQTT5_Userguide.md) and [MQTT5 PubSub Sample](./mqtt5_pubsub.py)
+
+<table>
+<tr>
+<th>Create a IotJobsClient with Mqtt5</th>
+<th>Create a IotJobsClient with Mqtt311</th>
+</tr>
+<tr>
+<td>
+
+```python
+  # Create a Mqtt5 Client
+  mqtt5_client = mqtt5_client_builder.mtls_from_path(
+          endpoint,
+          port,
+          cert_filepath,
+          pri_key_filepath,
+          ca_filepath,
+          client_id,
+          clean_session,
+          keep_alive_secs,
+          http_proxy_options,
+          on_lifecycle_connection_success,
+          on_lifecycle_stopped)
+
+  # Create the Jobs client from Mqtt5 Client
+  jobs_client = iotjobs.IotJobsClient(mqtt5_client)
+```
+
+</td>
+<td>
+
+```python
+    # Create a Mqtt311 Connection from the command line data
+    mqtt_connection = mqtt_connection_builder.mtls_from_path(
+        endpoint,
+        port,
+        cert_filepath,
+        pri_key_filepath,
+        ca_filepath,
+        client_id,
+        clean_session,
+        keep_alive_secs,
+        http_proxy_options)
+
+    # Create the Jobs client from Mqtt311 Connection
+    jobs_client = iotjobs.IotJobsClient(mqtt_connection)
+```
+
+</td>
+</tr>
+</table>
+
+### Mqtt5.QoS v.s. Mqtt3.QoS
+As the service client interface is unchanged for both Mqtt3 Connection and Mqtt5 Client,the IotJobsClient will use Mqtt3.QoS instead of Mqtt5.QoS even with a Mqtt5 Client. You could use mqtt3.QoS.to_mqtt5() and mqtt5.QoS.to_mqtt3() to convert the value.

--- a/samples/shadow.md
+++ b/samples/shadow.md
@@ -1,4 +1,4 @@
-# Shadow
+# Shadow MQTT5
 
 [**Return to main sample list**](./README.md)
 
@@ -76,12 +76,71 @@ To run the Shadow sample from the `samples` folder, use the following command:
 
 ``` sh
 # For Windows: replace 'python3' with 'python' and '/' with '\'
-python3 shadow.py --endpoint <endpoint> --cert <file> --key <file> --thing_name <name>
+python3 shadow_mqtt5.py --endpoint <endpoint> --cert <file> --key <file> --thing_name <name>
 ```
 
 You can also pass a Certificate Authority file (CA) if your certificate and key combination requires it:
 
 ``` sh
 # For Windows: replace 'python3' with 'python' and '/' with '\'
-python3 shadow.py --endpoint <endpoint> --cert <file> --key <file> --thing_name <name> --ca_file <file>
+python3 shadow_mqtt5.py --endpoint <endpoint> --cert <file> --key <file> --thing_name <name> --ca_file <file>
 ```
+
+## Service Client Notes
+### Difference relative to MQTT311 IotShadowClient
+The IotShadowClient with mqtt5 client is almost identical to mqtt3 one. The only difference is that you would need setup up a Mqtt5 Client and pass it to the IoTShadowClient.
+For how to setup a Mqtt5 Client, please refer to [MQTT5 UserGuide](../documents/MQTT5_Userguide.md) and [MQTT5 PubSub Sample](./mqtt5_pubsub.py)
+
+<table>
+<tr>
+<th>Create a IotShadowClient with Mqtt5</th>
+<th>Create a IotShadowClient with Mqtt311</th>
+</tr>
+<tr>
+<td>
+
+```python
+  # Create a Mqtt5 Client
+  mqtt5_client = mqtt5_client_builder.mtls_from_path(
+          endpoint,
+          port,
+          cert_filepath,
+          pri_key_filepath,
+          ca_filepath,
+          client_id,
+          clean_session,
+          keep_alive_secs,
+          http_proxy_options,
+          on_lifecycle_connection_success,
+          on_lifecycle_stopped)
+
+  # Create the shadow client from Mqtt5 Client
+  shadow_client = iotshadow.IotShadowClient(mqtt5_client)
+```
+
+</td>
+<td>
+
+```python
+    # Create a Mqtt311 Connection from the command line data
+    mqtt_connection = mqtt_connection_builder.mtls_from_path(
+        endpoint,
+        port,
+        cert_filepath,
+        pri_key_filepath,
+        ca_filepath,
+        client_id,
+        clean_session,
+        keep_alive_secs,
+        http_proxy_options)
+
+    # Create the shadow client from Mqtt311 Connection
+    shadow_client = iotshadow.IotShadowClient(mqtt_connection)
+```
+
+</td>
+</tr>
+</table>
+
+### Mqtt5.QoS v.s. Mqtt3.QoS
+As the service client interface is unchanged for both Mqtt3 Connection and Mqtt5 Client,the IoTShadowClient will use Mqtt3.QoS instead of Mqtt5.QoS even with a Mqtt5 Client. You could use mqtt3.QoS.to_mqtt5() and mqtt5.QoS.to_mqtt3() to convert the value.

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -43,7 +43,6 @@ future_connection_success = Future()
 shadow_thing_name = cmdData.input_thing_name
 shadow_property = cmdData.input_shadow_property
 
-TIMEOUT = 100
 SHADOW_VALUE_DEFAULT = "off"
 
 
@@ -73,7 +72,7 @@ def exit(msg_or_exception):
             locked_data.disconnect_called = True
             mqtt5_client.stop()
             # Signal that sample is finished
-            future_stopped.result(TIMEOUT)
+            future_stopped.result()
 
 # Callback for the lifecycle event Connection Success
 def on_lifecycle_connection_success(lifecycle_connect_success_data: mqtt5.LifecycleConnectSuccessData):
@@ -356,10 +355,10 @@ if __name__ == '__main__':
 
     # Wait for connection to be fully established.
     # Note that it's not necessary to wait, commands issued to the
-    # mqtt55_client before its fully connected will simply be queued.
+    # mqtt5_client before its fully connected will simply be queued.
     # But this sample waits here so it's obvious when a connection
     # fails or succeeds.
-    future_connection_success.result(TIMEOUT)
+    future_connection_success.result()
     print("Connected!")
 
     try:
@@ -378,7 +377,8 @@ if __name__ == '__main__':
             callback=on_update_shadow_rejected)
 
         # Wait for subscriptions to succeed
-        update_accepted_subscribed_future.result()
+        result = update_accepted_subscribed_future.result()
+        print("The type is : ",type(result))
         update_rejected_subscribed_future.result()
 
         print("Subscribing to Get responses...")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is a demonstration for mqtt5 service client changes and shadow sample.
The mqtt5 shadow will be in a separate sample file shadow_mqtt5.py in the final PR. 
Right now I use the mqtt3 shadow.py file to show the difference between two client version. 

The CI failed because the crt-python changes is not released. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
