### PR TITLE
Fix MQTT connection argument validation

### DIFF
--- a/awsiot/__init__.py
+++ b/awsiot/__init__.py
@@ -39,7 +39,7 @@ class MqttServiceClient:
             self._mqtt_connection = mqtt_connection.new_connection()
             self._mqtt5_client = mqtt_connection
         else:
-            raise ValueError("The service client could only take mqtt.Connection and mqtt5.Client as argument")
+            raise TypeError("The service client could only take mqtt.Connection and mqtt5.Client as argument")
 
     @property
     def mqtt_connection(self) -> mqtt.Connection:

--- a/awsiot/__init__.py
+++ b/awsiot/__init__.py
@@ -39,7 +39,7 @@ class MqttServiceClient:
             self._mqtt_connection = mqtt_connection.new_connection()
             self._mqtt5_client = mqtt_connection
         else:
-            assert("The service client could only take mqtt.Connection and mqtt5.Client as argument")
+            raise ValueError("The service client could only take mqtt.Connection and mqtt5.Client as argument")
 
     @property
     def mqtt_connection(self) -> mqtt.Connection:


### PR DESCRIPTION
assert "some string" will never raise an exception, would have to `assert False, "some string"`. 
Raising an `ValueError` seems to be more fitting here. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
