### PR TITLE
update awscrt, which now supports 32bit VSOCK ports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.20.0',
+        'awscrt==0.20.2',
     ],
     python_requires='>=3.7',
 )


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-c-io/issues/576

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
