### PR TITLE
Use ubuntu 22.04 for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   update-version:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # allow push
       pull-requests: write # allow making PR


### PR DESCRIPTION
*Issue #, if available:*

Ubuntu 20.04, which currently is used for release pipeline, is not available anymore.

*Description of changes:*

Use Ubuntu 22.04.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
