### PR TITLE
Raise minimum Python version to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
   osx:
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - macos-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.56
+  BUILDER_VERSION: v0.9.75
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-iot-device-sdk-python-v2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This document provides information about the AWS IoT Device SDK v2 for Python. T
 ## Installation
 
 ### Minimum Requirements
-* Python 3.7+
+* Python 3.8+
 
 [Step-by-step instructions](./documents/PREREQUISITES.md)
 

--- a/builder.json
+++ b/builder.json
@@ -43,11 +43,6 @@
                 ["/opt/python/cp38-cp38/bin/python", "-m", "pip", "install", ".", "--verbose"],
                 ["/opt/python/cp38-cp38/bin/python", "-m", "pip", "install", "boto3", "autopep8"],
                 ["/opt/python/cp38-cp38/bin/python", "-m", "unittest", "discover", "--verbose"],
-                ["echo", "------ Python 3.7 ------"],
-                ["/opt/python/cp37-cp37m/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
-                ["/opt/python/cp37-cp37m/bin/python", "-m", "pip", "install", ".", "--verbose"],
-                ["/opt/python/cp37-cp37m/bin/python", "-m", "pip", "install", "boto3", "autopep8"],
-                ["/opt/python/cp37-cp37m/bin/python", "-m", "unittest", "discover", "--verbose"]
             ],
             "run_tests": false,
             "_comment": "manylinux has all its own build steps, turn off 'tests' which is where normal build steps are declared. using data to program sucks"

--- a/builder.json
+++ b/builder.json
@@ -42,7 +42,7 @@
                 ["/opt/python/cp38-cp38/bin/python", "-m", "pip", "install", "--upgrade", "pip", "setuptools"],
                 ["/opt/python/cp38-cp38/bin/python", "-m", "pip", "install", ".", "--verbose"],
                 ["/opt/python/cp38-cp38/bin/python", "-m", "pip", "install", "boto3", "autopep8"],
-                ["/opt/python/cp38-cp38/bin/python", "-m", "unittest", "discover", "--verbose"],
+                ["/opt/python/cp38-cp38/bin/python", "-m", "unittest", "discover", "--verbose"]
             ],
             "run_tests": false,
             "_comment": "manylinux has all its own build steps, turn off 'tests' which is where normal build steps are declared. using data to program sucks"

--- a/documents/PREREQUISITES.md
+++ b/documents/PREREQUISITES.md
@@ -1,6 +1,6 @@
 # PREREQUISITES
 
-## Python 3.7 or higher
+## Python 3.8 or higher
 
 How you install Python varies from platform to platform. Below are the instructions for Windows, MacOS, and Linux:
 

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
     install_requires=[
         'awscrt==0.27.4',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
Drop Python 3.7 as it is EOL

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
