### PR TITLE
Fix: parse --count as int in mqtt5_pubsub.py sample

### DIFF
--- a/samples/mqtt5_pubsub.py
+++ b/samples/mqtt5_pubsub.py
@@ -24,7 +24,7 @@ parser.add_argument("--ca_file", dest="input_ca", help="Path to optional CA bund
 # Messaging
 parser.add_argument("--topic", default="test/topic", dest="input_topic", help="Topic")
 parser.add_argument("--message", default="Hello from mqtt5 sample", dest="input_message", help="Message payload")
-parser.add_argument("--count", default=5, dest="input_count",
+parser.add_argument("--count", type=int, default=5, dest="input_count",
                     help="Messages to publish (0 = infinite)")
 # Proxy
 parser.add_argument("--proxy-host", dest="input_proxy_host", help="HTTP proxy host")
@@ -79,7 +79,7 @@ def on_lifecycle_connection_failure(lifecycle_connection_failure: mqtt5.Lifecycl
 
 if __name__ == '__main__':
     print("\nStarting MQTT5 PubSub Sample\n")
-    message_count = args.input_count
+    message_count = int(args.input_count)
     message_topic = args.input_topic
     message_string = args.input_message
 


### PR DESCRIPTION
*Issue #, if available:*
Closes #643 

*Description of changes:*
1. Added type=int to the --count argument in mqtt5_pubsub.py so that it is always parsed as an integer.

2. Explicitly cast args.input_count to int when assigning message_count.

3. These changes fix a TypeError: '<=' not supported between instances of 'int' and 'str' that occurs when comparing publish_count to message_count.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
