### PR TITLE
Insignificant documentation fix

### DIFF
--- a/documents/MQTT5_Userguide.md
+++ b/documents/MQTT5_Userguide.md
@@ -8,7 +8,7 @@
     * [Not Supported](#not-supported)
 * [Getting Started with MQTT5](#getting-started-with-mqtt5)
     * [Connecting to AWS IoT Core](#connecting-to-aws-iot-core)
-    * [How to create an MQTT5 Client based on desired connection method](#how-to-create-a-mqtt5-client-based-on-desired-connection-method)
+    * [How to create an MQTT5 Client based on desired connection method](#how-to-create-an-mqtt5-client-based-on-desired-connection-method)
         * [Direct MQTT with X509-based mutual TLS](#direct-mqtt-with-x509-based-mutual-tls)
         * [Direct MQTT with Custom Authentication](#direct-mqtt-with-custom-authentication)
         * [Direct MQTT with PKCS11 Method](#direct-mqtt-with-pkcs11-method)

--- a/samples/README.md
+++ b/samples/README.md
@@ -20,7 +20,7 @@ This directory contains sample applications for [aws-iot-device-sdk-python-v2](.
 | [Websockets with Sigv4 authentication](./mqtt/mqtt5_aws_websocket.md) | Shows how to authenticate over websockets using AWS Signature Version 4 credentials. |
 | [AWS Custom Authorizer Lambda Function](./mqtt/mqtt5_custom_auth.md) | Examples of connecting with a signed and unsigned Lambda-backed custom authorizer.
 | [PKCS11](./mqtt/mqtt5_pkcs11_connect.md) | Demonstrates connecting using a hardware security module (HSM) or smartcard with PKCS#11. |
-| [Other Connection Methods](../documents/MQTT5_Userguide.md#how-to-create-a-mqtt5-client-based-on-desired-connection-method) | More connection methods are available for review in the MQTT5 Userguide
+| [Other Connection Methods](../documents/MQTT5_Userguide.md#how-to-create-an-mqtt5-client-based-on-desired-connection-method) | More connection methods are available for review in the MQTT5 Userguide
 
 ### Service Client Samples
 ##### AWS offers a number of IoT related services using MQTT. The samples below demonstrate how to use the service clients provided by the SDK to interact with those services.

--- a/samples/mqtt/mqtt5_aws_websocket.md
+++ b/samples/mqtt/mqtt5_aws_websocket.md
@@ -53,7 +53,7 @@ The AWS IAM permission policy associated with the AWS credentials resolved by th
       ]
     }
   ]
-}å
+}
 </pre>
 
 Replace with the following with the data from your AWS account:

--- a/samples/mqtt/mqtt5_custom_auth.md
+++ b/samples/mqtt/mqtt5_custom_auth.md
@@ -55,7 +55,7 @@ Below is a sample policy that provides the necessary privileges.
       ]
     }
   ]
-}å
+}
 </pre>
 
 Replace with the following with the data from your AWS account:

--- a/samples/mqtt/mqtt5_x509.md
+++ b/samples/mqtt/mqtt5_x509.md
@@ -55,7 +55,7 @@ Your IoT Core Thing's [Policy](https://docs.aws.amazon.com/iot/latest/developerg
       ]
     }
   ]
-}å
+}
 </pre>
 
 Replace with the following with the data from your AWS account:


### PR DESCRIPTION
Remove errant characters in various README files.
Fix some documentation links.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
