### PR TITLE
Remove rootca from AWS Websocket sample

### DIFF
--- a/samples/mqtt/mqtt5_aws_websocket.md
+++ b/samples/mqtt/mqtt5_aws_websocket.md
@@ -93,7 +93,6 @@ required arguments:
 
 optional arguments:
   --client_id        Client ID (default: mqtt5-sample-809571c8)
-  --ca_file          Path to optional CA bundle (PEM) (default: None)
   --topic            Topic (default: test/topic)
   --message          Message payload (default: Hello from mqtt5 sample)
   --count            Messages to publish (0 = infinite) (default: 5)

--- a/samples/mqtt/mqtt5_aws_websocket.py
+++ b/samples/mqtt/mqtt5_aws_websocket.py
@@ -24,8 +24,6 @@ required.add_argument("--signing_region", required=True,  metavar="", dest="inpu
 # Optional Arguments
 optional.add_argument("--client_id",  metavar="", dest="input_clientId", default=f"mqtt5-sample-{uuid.uuid4().hex[:8]}",
                       help="Client ID")
-optional.add_argument("--ca_file",  metavar="", dest="input_ca",
-                      help="Path to optional CA bundle (PEM)")
 optional.add_argument("--topic", default="test/topic",  metavar="", dest="input_topic",
                       help="Topic")
 optional.add_argument("--message", default="Hello from mqtt5 sample",  metavar="", dest="input_message",


### PR DESCRIPTION
Remove unecessary rootca arg from aws websocket sample


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
