### PR TITLE
Remove macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - macos-13
           - macos-latest
     permissions:
       id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
macos-13 is not available anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
