### PR TITLE
Update aws-crt to bring TLS 1.3 error on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'awscrt==0.31.0',
+        'awscrt==0.31.1',
     ],
     python_requires='>=3.8',
 )


### PR DESCRIPTION
Update awscrt to v0.31.1

This update includes returning error on using tls13 on macOS.
See https://github.com/awslabs/aws-c-io/pull/788

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
